### PR TITLE
Replace deprecated grey color

### DIFF
--- a/formatters.py
+++ b/formatters.py
@@ -92,7 +92,7 @@ def format_pull_request_event(payload: Dict[str, Any]) -> discord.Embed:
         'closed': discord.Color.red(),
         'reopened': discord.Color.orange(),
         'ready_for_review': discord.Color.blue(),
-        'draft': discord.Color.grey()
+        'draft': discord.Color.light_grey(),
     }
     
     color = color_map.get(action, discord.Color.blue())
@@ -206,7 +206,7 @@ def format_issue_event(payload: Dict[str, Any]) -> discord.Embed:
         'closed': discord.Color.red(),
         'reopened': discord.Color.orange(),
         'assigned': discord.Color.blue(),
-        'unassigned': discord.Color.grey()
+        'unassigned': discord.Color.light_grey(),
     }
     
     color = color_map.get(action, discord.Color.blue())


### PR DESCRIPTION
## Summary
- use `discord.Color.light_grey()` in pull request and issue color maps

## Testing
- `python -m py_compile formatters.py`


------
https://chatgpt.com/codex/tasks/task_e_686d6a36fb2c8332895dd9b9486d8cf1