### PR TITLE
Integrate configurable Discord webhook

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 # Discord Bot Configuration
 DISCORD_BOT_TOKEN=your_discord_bot_token_here
-DISCORD_WEBHOOK_URL=your_discord_webhook_url_here
+DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/your_webhook_id/your_webhook_token/github
 
 # GitHub Webhook Configuration
 GITHUB_WEBHOOK_SECRET=your_github_webhook_secret_here

--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ FastAPI-based webhook router that forwards GitHub events to Discord channels.
    ```bash
    python run.py
    ```
+
+### Environment Variables
+
+Set `DISCORD_WEBHOOK_URL` in your `.env` file to the Discord webhook you want to
+use for sending messages. For example:
+
+```ini
+DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/your_webhook_id/your_webhook_token/github
+```

--- a/add_all_webhooks.py
+++ b/add_all_webhooks.py
@@ -63,14 +63,7 @@ def add_webhook_to_repo(repo_name: str) -> bool:
     webhook_data = {
         "name": "web",
         "active": True,
-        "events": [
-            "push",
-            "pull_request", 
-            "issues",
-            "release",
-            "deployment_status",
-            "gollum"
-        ],
+        "events": ["*"],  # Subscribe to all available events
         "config": {
             "url": WEBHOOK_URL,
             "content_type": "json",

--- a/main.py
+++ b/main.py
@@ -67,7 +67,7 @@ async def route_github_event(event_type: str, payload: dict):
     """Route GitHub event to appropriate Discord channel."""
     if event_type == "push":
         embed = format_push_event(payload)
-        await send_to_discord(settings.channel_commits, embed=embed, use_webhook=True)
+        await send_to_discord(settings.channel_commits, embed=embed)
     elif event_type == "pull_request":
         action = payload.get("action")
         pr = payload.get("pull_request", {})
@@ -75,24 +75,24 @@ async def route_github_event(event_type: str, payload: dict):
         
         if action == "closed" and is_merged:
             embed = format_merge_event(payload)
-            await send_to_discord(settings.channel_code_merges, embed=embed, use_webhook=True)
+            await send_to_discord(settings.channel_code_merges, embed=embed)
         else:
             embed = format_pull_request_event(payload)
-            await send_to_discord(settings.channel_pull_requests, embed=embed, use_webhook=True)
+            await send_to_discord(settings.channel_pull_requests, embed=embed)
     elif event_type == "issues":
         embed = format_issue_event(payload)
-        await send_to_discord(settings.channel_issues, embed=embed, use_webhook=True)
+        await send_to_discord(settings.channel_issues, embed=embed)
     elif event_type == "release":
         embed = format_release_event(payload)
-        await send_to_discord(settings.channel_releases, embed=embed, use_webhook=True)
+        await send_to_discord(settings.channel_releases, embed=embed)
     elif event_type == "deployment_status":
         embed = format_deployment_event(payload)
-        await send_to_discord(settings.channel_deployment_status, embed=embed, use_webhook=True)
+        await send_to_discord(settings.channel_deployment_status, embed=embed)
     elif event_type == "gollum":
         embed = format_gollum_event(payload)
-        await send_to_discord(settings.channel_gollum, embed=embed, use_webhook=True)
+        await send_to_discord(settings.channel_gollum, embed=embed)
     else:
         embed = format_generic_event(event_type, payload)
-        await send_to_discord(settings.channel_bot_logs, embed=embed, use_webhook=True)
+        await send_to_discord(settings.channel_bot_logs, embed=embed)
     
     logger.info(f"Event {event_type} routed successfully.")


### PR DESCRIPTION
## Summary
- subscribe GitHub webhook setup script to all events
- route all events to mapped Discord channels
- document how to set the Discord webhook URL

## Testing
- `pytest -q`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_686d7e92a558833291c7275d8e5ce868