### PR TITLE
Add retroactive PR cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/your_webhook_id/your_web
 When a pull request is opened or marked ready for review, the bot records the Discord message ID in `pr_message_map.json`.
 Once the pull request is closed (merged or not), the stored message is automatically deleted from the `#pull-requests` channel.
 The JSON file maps `repo_name#pr_number` to the associated Discord message ID and is created at runtime in the project root.
+
+## Retroactive PR Cleanup
+
+If the bot missed deleting pull request messages (for example, it was offline when a PR was closed), you can remove outdated messages manually:
+
+```bash
+python pr_cleanup_tool.py
+```
+
+This script checks each entry in `pr_message_map.json`, queries the GitHub API to see if the PR is closed, and deletes the corresponding Discord message from the `#pull-requests` channel.

--- a/pr_cleanup_tool.py
+++ b/pr_cleanup_tool.py
@@ -1,0 +1,69 @@
+import asyncio
+import logging
+from typing import Dict
+
+import aiohttp
+
+from config import settings
+from discord_bot import discord_bot_instance
+from pr_map import load_pr_map, save_pr_map
+
+logger = logging.getLogger(__name__)
+GITHUB_API_BASE = "https://api.github.com"
+
+
+async def fetch_pr_state(session: aiohttp.ClientSession, repo: str, number: int) -> str:
+    """Fetch the state of a pull request from GitHub."""
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if settings.github_token:
+        headers["Authorization"] = f"token {settings.github_token}"
+
+    url = f"{GITHUB_API_BASE}/repos/{repo}/pulls/{number}"
+    try:
+        async with session.get(url, headers=headers) as resp:
+            if resp.status != 200:
+                logger.error(f"Failed to fetch PR {repo}#{number}: {resp.status}")
+                return "unknown"
+            data = await resp.json()
+            return data.get("state", "unknown")
+    except Exception as exc:
+        logger.error(f"Error fetching PR {repo}#{number}: {exc}")
+        return "unknown"
+
+
+async def cleanup_pr_messages() -> None:
+    """Delete channel messages for closed pull requests."""
+    pr_map_data: Dict[str, int] = load_pr_map()
+    if not pr_map_data:
+        logger.info("No PR messages to clean up.")
+        return
+
+    async with aiohttp.ClientSession() as session:
+        for key, message_id in list(pr_map_data.items()):
+            if "#" not in key:
+                continue
+            repo, num_str = key.split("#", 1)
+            state = await fetch_pr_state(session, repo, int(num_str))
+            if state == "closed":
+                success = await discord_bot_instance.delete_message_from_channel(
+                    settings.channel_pull_requests, message_id
+                )
+                if success:
+                    pr_map_data.pop(key)
+
+    save_pr_map(pr_map_data)
+
+
+async def main() -> None:
+    task = asyncio.create_task(discord_bot_instance.start())
+    while not discord_bot_instance.ready:
+        await asyncio.sleep(1)
+    try:
+        await cleanup_pr_messages()
+    finally:
+        await discord_bot_instance.bot.close()
+        await task
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_cleanup_tool.py
+++ b/tests/test_cleanup_tool.py
@@ -1,0 +1,58 @@
+import asyncio
+import tempfile
+from pathlib import Path
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import os
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
+
+import pr_map
+import pr_cleanup_tool
+from config import settings
+
+
+class TestCleanupTool(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.map_file = Path(self.tmpdir.name) / "map.json"
+        patcher = patch.object(pr_map, "PR_MAP_FILE", self.map_file)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def test_remove_closed_pr_message(self):
+        pr_map.save_pr_map({"test/repo#1": 111})
+        with patch(
+            "pr_cleanup_tool.fetch_pr_state",
+            new_callable=AsyncMock,
+            return_value="closed",
+        ), patch(
+            "discord_bot.discord_bot_instance.delete_message_from_channel",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_delete:
+            asyncio.run(pr_cleanup_tool.cleanup_pr_messages())
+            mock_delete.assert_awaited_with(settings.channel_pull_requests, 111)
+        data = pr_map.load_pr_map()
+        self.assertEqual(data, {})
+
+    def test_keep_open_pr_message(self):
+        pr_map.save_pr_map({"test/repo#2": 222})
+        with patch(
+            "pr_cleanup_tool.fetch_pr_state",
+            new_callable=AsyncMock,
+            return_value="open",
+        ), patch(
+            "discord_bot.discord_bot_instance.delete_message_from_channel",
+            new_callable=AsyncMock,
+        ) as mock_delete:
+            asyncio.run(pr_cleanup_tool.cleanup_pr_messages())
+            mock_delete.assert_not_called()
+        data = pr_map.load_pr_map()
+        self.assertEqual(data, {"test/repo#2": 222})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- provide `pr_cleanup_tool.py` for deleting outdated PR messages
- document script usage in README
- test PR cleanup tool

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5376ec28833284a62228c4897ab2