### PR TITLE
Add cleanup test

### DIFF
--- a/pr_cleanup.py
+++ b/pr_cleanup.py
@@ -1,0 +1,33 @@
+import aiohttp
+from config import settings
+from pr_map import load_pr_map, save_pr_map
+from discord_bot import discord_bot_instance
+
+
+async def cleanup_pr_messages() -> None:
+    """Remove messages for closed PRs and update the map."""
+    pr_map = load_pr_map()
+    if not pr_map:
+        return
+
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if settings.github_token:
+        headers["Authorization"] = f"token {settings.github_token}"
+
+    async with aiohttp.ClientSession() as session:
+        for pr_key, message_id in list(pr_map.items()):
+            repo, number = pr_key.split("#")
+            url = f"https://api.github.com/repos/{repo}/pulls/{number}"
+            async with session.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    continue
+                data = await resp.json()
+
+            if data.get("state") == "closed":
+                await discord_bot_instance.delete_message_from_channel(
+                    settings.channel_pull_requests,
+                    message_id,
+                )
+                pr_map.pop(pr_key)
+
+    save_pr_map(pr_map)

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,77 @@
+import asyncio
+import tempfile
+from pathlib import Path
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
+
+import pr_map
+from config import settings
+from pr_cleanup import cleanup_pr_messages
+
+
+class TestPRCleanupJob(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.map_file = Path(self.tmpdir.name) / "map.json"
+        patcher = patch.object(pr_map, "PR_MAP_FILE", self.map_file)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def test_cleanup_removes_closed_pr_messages(self):
+        pr_map.save_pr_map({
+            "test/repo#1": 111,
+            "test/repo#2": 222,
+        })
+
+        # Mock GitHub API responses
+        responses = {
+            "https://api.github.com/repos/test/repo/pulls/1": {"state": "closed"},
+            "https://api.github.com/repos/test/repo/pulls/2": {"state": "open"},
+        }
+
+        class MockResponse:
+            def __init__(self, data):
+                self.status = 200
+                self._data = data
+
+            async def json(self):
+                return self._data
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+        class MockSession:
+            def get(self, url, headers=None):
+                return MockResponse(responses[url])
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+        with patch("pr_cleanup.aiohttp.ClientSession", return_value=MockSession()), \
+             patch(
+                 "discord_bot.discord_bot_instance.delete_message_from_channel",
+                 new_callable=AsyncMock,
+             ) as mock_delete:
+            asyncio.run(cleanup_pr_messages())
+            mock_delete.assert_awaited_once_with(settings.channel_pull_requests, 111)
+
+        data = pr_map.load_pr_map()
+        self.assertEqual(data, {"test/repo#2": 222})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_cleanup.py
+++ b/tests/test_pr_cleanup.py
@@ -5,6 +5,9 @@ import unittest
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
 


### PR DESCRIPTION
## Summary
- implement `cleanup_pr_messages` to remove closed PR entries
- add regression test for cleanup logic
- patch existing PR cleanup tests for path resolution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5557dd748332ac7c03ea226dd2bf