### PR TITLE
Add Discord message retention purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,15 @@ use for sending messages. For example:
 DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/your_webhook_id/your_webhook_token/github
 ```
 
+You can control how long messages stay in key channels by setting `MESSAGE_RETENTION_DAYS`.
+If not set, messages older than 30 days are removed.
+
 ## Pull Request Message Cleanup
 
 When a pull request is opened or marked ready for review, the bot records the Discord message ID in `pr_message_map.json`.
 Once the pull request is closed (merged or not), the stored message is automatically deleted from the `#pull-requests` channel.
 The JSON file maps `repo_name#pr_number` to the associated Discord message ID and is created at runtime in the project root.
+
+## Message Retention
+
+Old messages can clutter channels. The bot automatically removes messages older than `MESSAGE_RETENTION_DAYS` from the commits, pull requests and releases channels during startup. Set this environment variable to control the retention period (default is 30 days).

--- a/config.py
+++ b/config.py
@@ -30,6 +30,9 @@ class Settings(BaseSettings):
     channel_deployment_status: int = 1392213551665381486
     channel_gollum: int = 1392213582963540028
     channel_bot_logs: int = 1392213610167664670
+
+    # Message retention configuration
+    message_retention_days: int = 30
     
     class Config:
         env_file = ".env"

--- a/main.py
+++ b/main.py
@@ -35,6 +35,18 @@ async def startup_event():
     logger.info("Starting up Discord bot...")
     asyncio.create_task(discord_bot_instance.start())
 
+    purge_channels = [
+        settings.channel_commits,
+        settings.channel_pull_requests,
+        settings.channel_releases,
+    ]
+    for channel_id in purge_channels:
+        asyncio.create_task(
+            discord_bot_instance.purge_old_messages(
+                channel_id, settings.message_retention_days
+            )
+        )
+
 
 @app.post("/github")
 async def github_webhook(request: Request):

--- a/tests/test_message_purge.py
+++ b/tests/test_message_purge.py
@@ -1,0 +1,77 @@
+import asyncio
+import importlib
+import os
+import tempfile
+from pathlib import Path
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
+
+import pr_map
+import config
+from discord_bot import discord_bot_instance
+
+
+class TestMessagePurge(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.pr_file = Path(self.tmpdir.name) / "map.json"
+        patcher = patch.object(pr_map, "PR_MAP_FILE", self.pr_file)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def test_startup_event_triggers_purge(self):
+        os.environ["MESSAGE_RETENTION_DAYS"] = "5"
+        importlib.reload(config)
+        import main
+        importlib.reload(main)
+
+        stored = []
+
+        def fake_create_task(coro):
+            stored.append(coro)
+            return MagicMock()
+
+        with patch.object(discord_bot_instance, "start", new_callable=AsyncMock), \
+             patch.object(discord_bot_instance, "purge_old_messages", new_callable=AsyncMock) as mock_purge, \
+             patch("asyncio.create_task", side_effect=fake_create_task):
+            asyncio.run(main.startup_event())
+
+        for coro in stored:
+            asyncio.run(coro)
+
+        channels = [
+            config.settings.channel_commits,
+            config.settings.channel_pull_requests,
+            config.settings.channel_releases,
+        ]
+        mock_purge.assert_has_awaits(
+            [call(channel, 5) for channel in channels], any_order=True
+        )
+
+    def test_purge_removes_pr_map_entries(self):
+        pr_map.save_pr_map({"repo#1": 111})
+
+        deleted_message = MagicMock()
+        deleted_message.id = 111
+
+        channel = MagicMock()
+        channel.purge = AsyncMock(return_value=[deleted_message])
+
+        discord_bot_instance.ready = True
+        with patch.object(discord_bot_instance.bot, "get_channel", return_value=channel):
+            asyncio.run(
+                discord_bot_instance.purge_old_messages(
+                    config.settings.channel_pull_requests, 1
+                )
+            )
+
+        data = pr_map.load_pr_map()
+        self.assertEqual(data, {})
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add `message_retention_days` config
- purge old Discord messages on startup and cleanup PR map
- handle message purging in `DiscordBot`
- document new behaviour in README
- test purge scheduling and map cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e55643d588332ae7d06aaf799013d