### PR TITLE
Add CI workflow routing

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
     channel_issues: int = 1392213509382737991
     channel_releases: int = 1392213528542445628
     channel_deployment_status: int = 1392213551665381486
+    channel_ci_builds: int = 1392457950169268334
     channel_gollum: int = 1392213582963540028
     channel_bot_logs: int = 1392213610167664670
 

--- a/main.py
+++ b/main.py
@@ -23,6 +23,10 @@ from formatters import (
     format_release_event,
     format_deployment_event,
     format_gollum_event,
+    format_workflow_run,
+    format_workflow_job,
+    format_check_run,
+    format_check_suite,
     format_generic_event
 )
 
@@ -132,6 +136,18 @@ async def route_github_event(event_type: str, payload: dict):
     elif event_type == "deployment_status":
         embed = format_deployment_event(payload)
         await send_to_discord(settings.channel_deployment_status, embed=embed)
+    elif event_type == "workflow_run":
+        embed = format_workflow_run(payload)
+        await send_to_discord(settings.channel_ci_builds, embed=embed)
+    elif event_type == "workflow_job":
+        embed = format_workflow_job(payload)
+        await send_to_discord(settings.channel_ci_builds, embed=embed)
+    elif event_type == "check_run":
+        embed = format_check_run(payload)
+        await send_to_discord(settings.channel_ci_builds, embed=embed)
+    elif event_type == "check_suite":
+        embed = format_check_suite(payload)
+        await send_to_discord(settings.channel_ci_builds, embed=embed)
     elif event_type == "gollum":
         embed = format_gollum_event(payload)
         await send_to_discord(settings.channel_gollum, embed=embed)

--- a/tests/test_ci_routing.py
+++ b/tests/test_ci_routing.py
@@ -1,0 +1,57 @@
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
+
+import main
+from config import settings
+
+
+def load_payload(name: str) -> dict:
+    payload_dir = Path(__file__).parent / "payloads"
+    with open(payload_dir / name, "r") as f:
+        return json.load(f)
+
+
+class TestCIRouting:
+    def test_route_workflow_run(self):
+        payload = load_payload("workflow_run.json")
+        embed = MagicMock()
+        with patch("main.format_workflow_run", return_value=embed) as fmt, \
+             patch("main.send_to_discord", new_callable=AsyncMock) as send:
+            asyncio.run(main.route_github_event("workflow_run", payload))
+            fmt.assert_called_once_with(payload)
+            send.assert_awaited_once_with(settings.channel_ci_builds, embed=embed)
+
+    def test_route_workflow_job(self):
+        payload = load_payload("workflow_job.json")
+        embed = MagicMock()
+        with patch("main.format_workflow_job", return_value=embed) as fmt, \
+             patch("main.send_to_discord", new_callable=AsyncMock) as send:
+            asyncio.run(main.route_github_event("workflow_job", payload))
+            fmt.assert_called_once_with(payload)
+            send.assert_awaited_once_with(settings.channel_ci_builds, embed=embed)
+
+    def test_route_check_run(self):
+        payload = load_payload("check_run.json")
+        embed = MagicMock()
+        with patch("main.format_check_run", return_value=embed) as fmt, \
+             patch("main.send_to_discord", new_callable=AsyncMock) as send:
+            asyncio.run(main.route_github_event("check_run", payload))
+            fmt.assert_called_once_with(payload)
+            send.assert_awaited_once_with(settings.channel_ci_builds, embed=embed)
+
+    def test_route_check_suite(self):
+        payload = load_payload("check_suite.json")
+        embed = MagicMock()
+        with patch("main.format_check_suite", return_value=embed) as fmt, \
+             patch("main.send_to_discord", new_callable=AsyncMock) as send:
+            asyncio.run(main.route_github_event("check_suite", payload))
+            fmt.assert_called_once_with(payload)
+            send.assert_awaited_once_with(settings.channel_ci_builds, embed=embed)


### PR DESCRIPTION
## Summary
- add channel_ci_builds to config
- route CI workflow events in `route_github_event`
- test that workflow events are routed to CI channel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6c78ec808332bdadd8badf088af6