### PR TITLE
Fix duplicate cleanup import

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,8 +9,6 @@ from logging_config import setup_logging
 from config import settings
 from discord_bot import send_to_discord, discord_bot_instance
 
-from cleanup import cleanup_pr_messages
-
 from cleanup_pr_messages import cleanup_pr_messages
 
 from pr_map import load_pr_map, save_pr_map


### PR DESCRIPTION
## Summary
- remove duplicate import of cleanup_pr_messages
- ensure startup_event uses the intended cleanup function

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6c76fbcc8332ba30113e46170913