### PR TITLE
Fix startup cleanup import

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,8 +11,6 @@ from discord_bot import send_to_discord, discord_bot_instance
 
 from cleanup import cleanup_pr_messages
 
-from cleanup_pr_messages import cleanup_pr_messages
-
 from pr_map import load_pr_map, save_pr_map
 from github_utils import verify_github_signature, is_github_event_relevant
 from formatters import (

--- a/tests/test_message_purge.py
+++ b/tests/test_message_purge.py
@@ -36,6 +36,7 @@ class TestMessagePurge(unittest.TestCase):
 
         with patch.object(discord_bot_instance, "start", new_callable=AsyncMock), \
              patch.object(discord_bot_instance, "purge_old_messages", new_callable=AsyncMock) as mock_purge, \
+             patch("main.cleanup_pr_messages", new_callable=AsyncMock) as mock_cleanup, \
              patch("asyncio.create_task", side_effect=fake_create_task):
             asyncio.run(main.startup_event())
 
@@ -50,6 +51,7 @@ class TestMessagePurge(unittest.TestCase):
         mock_purge.assert_has_awaits(
             [call(channel, 5) for channel in channels], any_order=True
         )
+        mock_cleanup.assert_awaited_once()
 
     def test_purge_removes_pr_map_entries(self):
         pr_map.save_pr_map({"repo#1": 111})


### PR DESCRIPTION
## Summary
- fix duplicate cleanup import in `main.py`
- verify startup schedules cleanup task in tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6db776a88332a9eb4b5893ec3f48