### PR TITLE
Add requests dependency and stub handler

### DIFF
--- a/pull_request_handler.py
+++ b/pull_request_handler.py
@@ -1,0 +1,3 @@
+async def handle_pull_request_event_with_retry(payload: dict) -> bool:
+    """Stub handler for pull request events."""
+    return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ aiohttp>=3.9.0
 python-dotenv>=1.0.0
 pydantic>=2.10.0
 pydantic-settings>=2.0.0
+
+requests>=2.31.0
+httpx>=0.27.0


### PR DESCRIPTION
## Summary
- include `requests` and `httpx` in requirements
- add missing `pull_request_handler` module so imports succeed

## Testing
- `pytest -q` *(fails: delete_message_from_channel not awaited)*

------
https://chatgpt.com/codex/tasks/task_e_686e7614e72c83329974ad047a59537d