### PR TITLE
Implement GitHub stats updater

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -99,6 +99,26 @@ class DiscordBot:
             except Exception:
                 pass
 
+    async def update_channel_name(self, channel_id: int, new_name: str) -> bool:
+        """Rename a Discord channel."""
+        try:
+            channel = self.bot.get_channel(channel_id)
+            if not channel:
+                logger.error(f"Channel {channel_id} not found for rename")
+                return False
+
+            await channel.edit(name=new_name)
+            return True
+        except Exception as e:
+            logger.error(f"Failed to rename channel {channel_id}: {e}")
+            try:
+                logs_channel = self.bot.get_channel(settings.channel_bot_logs)
+                if logs_channel:
+                    await logs_channel.send(f"❌ Failed to rename channel {channel_id}: {e}")
+            except Exception:
+                pass
+            return False
+
     async def send_to_webhook(self, url: str, content: str = None, embed: discord.Embed = None):
         """Send a message to a Discord webhook URL."""
         import aiohttp

--- a/github_utils.py
+++ b/github_utils.py
@@ -46,5 +46,72 @@ def is_github_event_relevant(event_type: str, payload: dict) -> bool:
         action = payload.get("action")
         if action in skip_actions[event_type]:
             return False
-    
+
     return True
+
+
+async def fetch_repo_stats() -> dict:
+    """Fetch commit, pull request and merge counts for the user's repositories."""
+    import aiohttp
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    if not settings.github_username:
+        logger.warning("GitHub username not configured; skipping stats fetch")
+        return {}
+
+    headers = {"Accept": "application/vnd.github+json"}
+    if settings.github_token:
+        headers["Authorization"] = f"token {settings.github_token}"  # pragma: no cover - optional auth
+
+    repos_url = f"https://api.github.com/users/{settings.github_username}/repos"
+
+    stats: dict = {}
+    async with aiohttp.ClientSession() as session:
+        try:
+            async with session.get(repos_url, headers=headers) as resp:
+                if resp.status != 200:
+                    logger.error("Failed to fetch repositories: %s", resp.status)
+                    return {}
+                repos = await resp.json()
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.error("Error fetching repositories: %s", exc)
+            return {}
+
+        for repo in repos:
+            name = repo.get("full_name")
+            if not name:
+                continue
+            stats[name] = {"commits": 0, "pull_requests": 0, "merges": 0}
+
+            commits_url = f"https://api.github.com/repos/{name}/commits?per_page=1"
+            pulls_url = f"https://api.github.com/repos/{name}/pulls?state=all&per_page=1"
+            merges_url = f"https://api.github.com/repos/{name}/pulls?state=closed&per_page=1"
+
+            try:
+                async with session.get(commits_url, headers=headers) as c_resp:
+                    if "link" in c_resp.headers:
+                        link = c_resp.headers["link"]
+                        if "last" in link:
+                            last_part = link.split(",")[-1]
+                            if "page=" in last_part:
+                                stats[name]["commits"] = int(last_part.split("page=")[-1].split(" ")[0])
+                async with session.get(pulls_url, headers=headers) as p_resp:
+                    if "link" in p_resp.headers:
+                        link = p_resp.headers["link"]
+                        if "last" in link:
+                            part = link.split(",")[-1]
+                            if "page=" in part:
+                                stats[name]["pull_requests"] = int(part.split("page=")[-1].split(" ")[0])
+                async with session.get(merges_url, headers=headers) as m_resp:
+                    if "link" in m_resp.headers:
+                        link = m_resp.headers["link"]
+                        if "last" in link:
+                            part = link.split(",")[-1]
+                            if "page=" in part:
+                                stats[name]["merges"] = int(part.split("page=")[-1].split(" ")[0])
+            except Exception:  # pragma: no cover - network failures
+                logger.error("Error fetching stats for repo %s", name)
+
+    return stats

--- a/pull_request_handler.py
+++ b/pull_request_handler.py
@@ -1,0 +1,51 @@
+"""Handle pull request webhook events with basic state tracking."""
+
+import logging
+from typing import Dict
+
+from config import settings
+from discord_bot import discord_bot_instance
+from formatters import format_pull_request_event
+from pr_map import load_pr_map, save_pr_map
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_pull_request_event_with_retry(payload: Dict) -> bool:
+    """Process pull request events and update Discord messages."""
+    action = payload.get("action")
+    pr = payload.get("pull_request", {})
+    repo = payload.get("repository", {})
+    repo_name = repo.get("full_name")
+    number = pr.get("number")
+    if not repo_name or number is None:
+        logger.error("Missing PR information in payload")
+        return False
+
+    key = f"{repo_name}#{number}"
+    pr_map = load_pr_map()
+
+    if action == "opened":
+        from main import send_to_discord  # imported here to avoid circular import
+        embed = format_pull_request_event(payload)
+        message = await send_to_discord(settings.channel_pull_requests, embed=embed)
+        if message:
+            pr_map[key] = message.id
+            save_pr_map(pr_map)
+        return True
+
+    if action == "closed":
+        message_id = pr_map.pop(key, None)
+        if message_id:
+            await discord_bot_instance.delete_message_from_channel(
+                settings.channel_pull_requests,
+                message_id,
+            )
+            save_pr_map(pr_map)
+        return True
+
+    # For other actions, just post the embed without tracking
+    from main import send_to_discord
+    embed = format_pull_request_event(payload)
+    await send_to_discord(settings.channel_pull_requests, embed=embed)
+    return True

--- a/tests/test_ci_routing.py
+++ b/tests/test_ci_routing.py
@@ -24,7 +24,8 @@ class TestCIRouting:
         payload = load_payload("workflow_run.json")
         embed = MagicMock()
         with patch("main.format_workflow_run", return_value=embed) as fmt, \
-             patch("main.send_to_discord", new_callable=AsyncMock) as send:
+             patch("main.send_to_discord", new_callable=AsyncMock) as send, \
+             patch("main.update_github_stats", new_callable=AsyncMock):
             asyncio.run(main.route_github_event("workflow_run", payload))
             fmt.assert_called_once_with(payload)
             send.assert_awaited_once_with(settings.channel_ci_builds, embed=embed)
@@ -33,7 +34,8 @@ class TestCIRouting:
         payload = load_payload("workflow_job.json")
         embed = MagicMock()
         with patch("main.format_workflow_job", return_value=embed) as fmt, \
-             patch("main.send_to_discord", new_callable=AsyncMock) as send:
+             patch("main.send_to_discord", new_callable=AsyncMock) as send, \
+             patch("main.update_github_stats", new_callable=AsyncMock):
             asyncio.run(main.route_github_event("workflow_job", payload))
             fmt.assert_called_once_with(payload)
             send.assert_awaited_once_with(settings.channel_ci_builds, embed=embed)
@@ -42,7 +44,8 @@ class TestCIRouting:
         payload = load_payload("check_run.json")
         embed = MagicMock()
         with patch("main.format_check_run", return_value=embed) as fmt, \
-             patch("main.send_to_discord", new_callable=AsyncMock) as send:
+             patch("main.send_to_discord", new_callable=AsyncMock) as send, \
+             patch("main.update_github_stats", new_callable=AsyncMock):
             asyncio.run(main.route_github_event("check_run", payload))
             fmt.assert_called_once_with(payload)
             send.assert_awaited_once_with(settings.channel_ci_builds, embed=embed)
@@ -51,7 +54,8 @@ class TestCIRouting:
         payload = load_payload("check_suite.json")
         embed = MagicMock()
         with patch("main.format_check_suite", return_value=embed) as fmt, \
-             patch("main.send_to_discord", new_callable=AsyncMock) as send:
+             patch("main.send_to_discord", new_callable=AsyncMock) as send, \
+             patch("main.update_github_stats", new_callable=AsyncMock):
             asyncio.run(main.route_github_event("check_suite", payload))
             fmt.assert_called_once_with(payload)
             send.assert_awaited_once_with(settings.channel_ci_builds, embed=embed)

--- a/tests/test_github_stats.py
+++ b/tests/test_github_stats.py
@@ -1,0 +1,49 @@
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+import unittest
+import discord
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
+
+import main
+from config import settings
+from discord_bot import discord_bot_instance
+
+
+class TestGithubStats(unittest.TestCase):
+    def test_update_stats_renames_and_posts(self):
+        sample_stats = {
+            "repo1": {"commits": 5, "pull_requests": 2, "merges": 1},
+            "repo2": {"commits": 3, "pull_requests": 1, "merges": 1},
+        }
+
+        msg = MagicMock()
+        msg.id = 123
+
+        with patch("main.fetch_repo_stats", new_callable=AsyncMock, return_value=sample_stats) as fetch, \
+             patch.object(discord_bot_instance, "update_channel_name", new_callable=AsyncMock) as rename, \
+             patch("main.send_to_discord", new_callable=AsyncMock, return_value=msg) as send:
+            asyncio.run(main.update_github_stats())
+
+        fetch.assert_awaited_once()
+        rename.assert_has_awaits(
+            [
+                unittest.mock.call(settings.channel_commits, "8-commits"),
+                unittest.mock.call(settings.channel_pull_requests, "3-pull-requests"),
+                unittest.mock.call(settings.channel_code_merges, "2-merges"),
+            ],
+            any_order=False,
+        )
+        self.assertEqual(send.await_count, 3)
+        for call_args in send.await_args_list:
+            self.assertIn("embed", call_args.kwargs)
+            self.assertIsInstance(call_args.kwargs["embed"], discord.Embed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_message_purge.py
+++ b/tests/test_message_purge.py
@@ -37,6 +37,7 @@ class TestMessagePurge(unittest.TestCase):
         with patch.object(discord_bot_instance, "start", new_callable=AsyncMock), \
              patch.object(discord_bot_instance, "purge_old_messages", new_callable=AsyncMock) as mock_purge, \
              patch("main.cleanup_pr_messages", new_callable=AsyncMock) as mock_cleanup, \
+             patch("main.update_github_stats", new_callable=AsyncMock), \
              patch("asyncio.create_task", side_effect=fake_create_task):
             asyncio.run(main.startup_event())
 

--- a/tests/test_pr_cleanup.py
+++ b/tests/test_pr_cleanup.py
@@ -38,7 +38,8 @@ class TestPRMessageCleanup(unittest.TestCase):
             },
             "repository": {"full_name": "test/repo"},
         }
-        with patch("main.send_to_discord", new_callable=AsyncMock, return_value=message):
+        with patch("main.send_to_discord", new_callable=AsyncMock, return_value=message), \
+             patch("main.update_github_stats", new_callable=AsyncMock):
             asyncio.run(main.route_github_event("pull_request", payload))
         data = pr_map.load_pr_map()
         self.assertEqual(data.get("test/repo#1"), 123)
@@ -61,7 +62,8 @@ class TestPRMessageCleanup(unittest.TestCase):
              patch(
                  "discord_bot.discord_bot_instance.delete_message_from_channel",
                  new_callable=AsyncMock,
-             ) as mock_delete:
+             ) as mock_delete, \
+             patch("main.update_github_stats", new_callable=AsyncMock):
             asyncio.run(main.route_github_event("pull_request", payload))
             mock_delete.assert_awaited_with(settings.channel_pull_requests, 456)
         data = pr_map.load_pr_map()


### PR DESCRIPTION
## Summary
- add ability to rename Discord channels
- fetch GitHub repository stats from API
- update overview channels and embed summaries
- track pull request messages in new handler
- test GitHub stats updating

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7822a98083329edeb53f079984cc