### PR TITLE
Add clear command for dev channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,5 +114,15 @@ python pr_cleanup_tool.py
 
 This script checks each entry in `pr_message_map.json`, queries the GitHub API to see if the PR is closed, and deletes the corresponding Discord message from the `#pull-requests` channel.
 
+## Clearing Development Channels
+
+To quickly remove **all** messages from the development channels, type:
+
+```bash
+!clear
+```
+
+The command iterates over the configured development channels and purges every message, providing a clean slate for testing.
+
 
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -22,6 +22,22 @@ intents.message_content = True
 # Create bot instance
 bot = commands.Bot(command_prefix="!", intents=intents)
 
+# Channels used during development that can be purged with the `!clear` command
+DEV_CHANNELS: list[int] = [
+    settings.channel_commits,
+    settings.channel_pull_requests,
+    settings.channel_releases,
+    settings.channel_code_merges,
+    settings.channel_commits_overview,
+    settings.channel_pull_requests_overview,
+    settings.channel_merges_overview,
+    settings.channel_issues,
+    settings.channel_deployment_status,
+    settings.channel_ci_builds,
+    settings.channel_gollum,
+    settings.channel_bot_logs,
+]
+
 
 class DiscordBot:
     """Discord bot wrapper for sending GitHub webhook messages."""
@@ -239,3 +255,11 @@ async def send_to_discord(
             )
     else:
         return await discord_bot_instance.send_to_channel(channel_id, content, embed)
+
+
+@bot.command(name="clear")
+async def clear_channels(ctx: commands.Context) -> None:
+    """Clear all messages from development channels."""
+    for channel_id in DEV_CHANNELS:
+        await discord_bot_instance.purge_old_messages(channel_id, 0)
+    await ctx.send("✅ Channels cleared.")

--- a/tests/test_clear_command.py
+++ b/tests/test_clear_command.py
@@ -1,0 +1,30 @@
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, call, MagicMock, patch
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
+
+from discord_bot import clear_channels, DEV_CHANNELS, discord_bot_instance
+
+
+class TestClearCommand(unittest.TestCase):
+    def test_clear_purges_all_channels(self):
+        ctx = MagicMock()
+        ctx.send = AsyncMock()
+        with patch.object(
+            discord_bot_instance, "purge_old_messages", new_callable=AsyncMock
+        ) as mock_purge:
+            asyncio.run(clear_channels(ctx))
+            mock_purge.assert_has_awaits(
+                [call(ch, 0) for ch in DEV_CHANNELS], any_order=True
+            )
+        ctx.send.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- centralize development channel IDs in `DEV_CHANNELS`
- add `!clear` command to purge all dev channels
- document new command
- test `!clear` purges every channel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fd1286a1c833287bd0484a9726591