### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ To quickly remove **all** messages from the development channels, type:
 
 The command iterates over the configured development channels and purges every message, providing a clean slate for testing.
 
+## Continuous Integration
+
+Automated tests run with GitHub Actions. The workflow defined in
+`.github/workflows/ci.yml` installs Python 3.11, installs the project
+dependencies along with `pytest`, and executes the test suite with
+`pytest -q` for each push and pull request.
+
 ## Discord Bot Commands
 
 The bot provides a few convenience commands when interacting directly in Discord.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for running tests on Python 3.11
- document the workflow in a new **Continuous Integration** section of the README

## Testing
- `pytest -q` *(fails: IndentationError and ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687001d7073c8332be4f49dbbdf9d3a2