### PR TITLE
Add troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 FastAPI-based webhook router that forwards GitHub events to Discord channels. This document provides a complete setup guide and instructions for maintaining each component, including GitHub webhooks.
 
+Additional setup and troubleshooting details can be found in the [docs directory](docs/README.md).
+
 ## How to Re-run the Webhook Script
 
 To re-run the webhook script `add_all_webhooks.py` when new repositories are created, follow these steps:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# Discord GitHub Bot Documentation
+
+This directory contains extended documentation for setting up and operating the bot.
+
+## Setup
+
+### Webhook Secret
+1. In GitHub, open your repository **Settings** → **Webhooks** and click **Add webhook**.
+2. Enter the payload URL of your running bot (e.g. `https://example.com/github`).
+3. Choose `application/json` as the content type.
+4. Set a **secret** to secure incoming requests.
+5. Add the same value to your `.env` file under `GITHUB_WEBHOOK_SECRET`.
+
+### Discord Permissions
+1. Create a Discord bot in the [Developer Portal](https://discord.com/developers/applications).
+2. On the **Bot** tab enable the permissions your channels require (e.g. `Send Messages`, `Embed Links`).
+3. Invite the bot to your server with these permissions.
+4. Record the channel IDs for each target channel and set them in your `.env`.
+
+## Troubleshooting
+
+### Hitting Rate Limits
+- GitHub or Discord may throttle requests when activity spikes.
+- Reduce message volume or batch updates to avoid bursts.
+
+### Missing Channels
+- If the bot logs errors about unknown channel IDs, verify the IDs in `.env`.
+- Ensure the bot has access to each channel and the required permissions to post.
+
+## Extending Event Formatters
+
+Formatter functions in `formatters.py` create rich embeds from webhook payloads.
+To support a new GitHub event:
+1. Add a new `format_<event>` function to `formatters.py`.
+2. Include any icons or colors that distinguish the event.
+3. Update the router in `main.py` to call the new formatter and direct messages to the correct channel.
+4. Write tests covering the formatter logic and routing.
+


### PR DESCRIPTION
## Summary
- add new documentation for setting up webhook secrets and Discord permissions
- include troubleshooting notes and how to extend formatters
- link new docs from README

## Testing
- `pytest -q` *(fails: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68700214b9b083329ded9e204e3df83a