### PR TITLE
Make AGENTS directory configurable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -12,6 +12,9 @@ WEBHOOK_URL=http://65.21.253.0:8000/github
 HOST=0.0.0.0
 PORT=8000
 
+# Agent directories
+AGENTS_DIR=/path/to/agents
+
 # Discord Channel IDs (from AGENTS.md)
 
 CHANNEL_COMMITS=1392467209162592266

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ use for sending messages. For example:
 DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/your_webhook_id/your_webhook_token/github
 ```
 
+Set `AGENTS_DIR` to specify where logs and state files are stored. If not set, the
+current working directory is used.
+
 You can control how long messages stay in key channels by setting `MESSAGE_RETENTION_DAYS`.
 If not set, messages older than 30 days are removed.
 

--- a/agents_config.py
+++ b/agents_config.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import os
 
 # AGENTS.MD compliant canonical directory
-AGENTS_CANONICAL_DIR = Path("/home/cinder/Documents/Agents")
+# Configurable via the AGENTS_DIR environment variable, defaults to current directory
+AGENTS_CANONICAL_DIR = Path(os.getenv("AGENTS_DIR", Path.cwd()))
 
 # Subdirectories
 AGENTS_LOGS_DIR = AGENTS_CANONICAL_DIR / "logs"

--- a/agents_health_check.py
+++ b/agents_health_check.py
@@ -2,6 +2,7 @@
 """Health check script for AGENTS.MD compliance."""
 
 import sys
+import os
 from pathlib import Path
 from agents_config import AGENT_METADATA, AGENTS_CANONICAL_DIR, LOGS_DIR, STATE_DIR
 
@@ -35,6 +36,13 @@ def check_agent_compliance():
     """Check if the agent is compliant with AGENTS.MD specifications."""
     print("🔍 Checking AGENTS.MD compliance...")
     print("=" * 50)
+
+    # Display the directory source
+    env_value = os.getenv("AGENTS_DIR")
+    if env_value:
+        print(f"🌐 Using AGENTS_DIR from environment: {env_value}")
+    else:
+        print("🌐 AGENTS_DIR not set; using current directory")
 
     # Check canonical directory
     print(f"📁 Canonical directory: {AGENTS_CANONICAL_DIR}")

--- a/logging_config.py
+++ b/logging_config.py
@@ -2,10 +2,12 @@
 
 import logging
 import logging.handlers
+import os
 from pathlib import Path
 
 # Canonical directory for agent logs and state
-AGENTS_DIR = Path("/home/cinder/Documents/Agents")
+# Use environment variable to allow customization. Default to current directory.
+AGENTS_DIR = Path(os.getenv("AGENTS_DIR", Path.cwd()))
 LOGS_DIR = AGENTS_DIR / "logs"
 STATE_DIR = AGENTS_DIR / "state"
 


### PR DESCRIPTION
## Summary
- add `AGENTS_DIR` env var in `logging_config.py`
- allow `agents_config.py` to use the new variable
- expose the chosen directory in the health check
- document the new setting in README and `.env.template`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870020e47d88332bc255dd88ce068f7