### PR TITLE
Refactor github_utils helpers

### DIFF
--- a/github_utils.py
+++ b/github_utils.py
@@ -1,30 +1,22 @@
-"""GitHub webhook utilities for signature verification."""
+"""Utility helpers for GitHub API interactions.
+
+This module provides functions for verifying webhook signatures,
+filtering irrelevant events and collecting repository statistics.
+"""
+
+from __future__ import annotations
 
 import hashlib
 import hmac
 import logging
-
-from dataclasses import dataclass
-from typing import Optional, List
-
-import aiohttp
-from fastapi import Request, HTTPException
-
-from typing import Optional, List, Dict, Tuple
-
-import aiohttp
-from fastapi import Request, HTTPException
-from typing import Optional, List
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
 import aiohttp
-
-
+from fastapi import HTTPException, Request
 
 from config import settings
-
-logger = logging.getLogger(__name__)
-
 
 logger = logging.getLogger(__name__)
 
@@ -32,55 +24,39 @@ GITHUB_API_BASE = "https://api.github.com"
 
 
 async def verify_github_signature(request: Request, body: bytes) -> None:
-    """Verify the GitHub webhook signature."""
+    """Validate the request body against the ``X-Hub-Signature-256`` header."""
     if not settings.github_webhook_secret:
-        # If no secret is configured, skip verification
         return
 
     signature = request.headers.get("X-Hub-Signature-256")
     if not signature:
-        raise HTTPException(
-            status_code=401, detail="Missing X-Hub-Signature-256 header"
-        )
+        raise HTTPException(status_code=401, detail="Missing X-Hub-Signature-256 header")
 
-    # Calculate the expected signature
-    expected_signature = hmac.new(
+    expected = hmac.new(
         settings.github_webhook_secret.encode("utf-8"), body, hashlib.sha256
     ).hexdigest()
+    expected = f"sha256={expected}"
 
-    # GitHub prefixes the signature with "sha256="
-    expected_signature = f"sha256={expected_signature}"
-
-    # Compare signatures
-    if not hmac.compare_digest(signature, expected_signature):
+    if not hmac.compare_digest(signature, expected):
         raise HTTPException(status_code=401, detail="Invalid signature")
 
 
 def is_github_event_relevant(event_type: str, payload: dict) -> bool:
-    """Check if the GitHub event is relevant and should be processed."""
-    # Skip some events that might be too noisy
+    """Return ``True`` if the event should be processed."""
     skip_actions = {
         "pull_request": ["synchronize", "edited", "review_requested"],
         "issues": ["edited", "labeled", "unlabeled"],
-        "push": [],  # Process all push events
+        "push": [],
     }
 
-    if event_type in skip_actions:
-        action = payload.get("action")
-        if action in skip_actions[event_type]:
-            return False
-
+    if event_type in skip_actions and payload.get("action") in skip_actions[event_type]:
+        return False
     return True
 
 
-import aiohttp
-
-GITHUB_API_BASE = "https://api.github.com"
-
-
-async def _extract_total_from_link(link_header: Optional[str]) -> int:
-    """Extract the last page number from a GitHub pagination link header."""
-    if not link_header or "rel=\"last\"" not in link_header:
+def _extract_total_from_link(link_header: Optional[str]) -> int:
+    """Parse the ``Link`` header from GitHub pagination and return the last page."""
+    if not link_header or 'rel="last"' not in link_header:
         return 1
     for part in link_header.split(','):
         if 'rel="last"' in part:
@@ -93,26 +69,15 @@ async def _extract_total_from_link(link_header: Optional[str]) -> int:
     return 1
 
 
-async def fetch_repo_stats() -> tuple[dict[str, dict[str, int]], dict[str, int]]:
-    """Fetch commit and pull request stats for all repos owned by the user."""
-    if not settings.github_username:
-        raise ValueError("github_username not configured")
-
-
-
-
-@dataclass
-class RepoStats:
-    """Statistics for a single repository."""
-
-    name: str
-    commits: int
-    pull_requests: int
-    merges: int
-
-
-async def gather_repo_stats() -> List[RepoStats]:
-    """Gather commit, PR and merge counts for each repository."""
+async def _get_paginated_count(session: aiohttp.ClientSession, url: str, headers: Dict[str, str]) -> int:
+    """Return the item count for a paginated GitHub endpoint."""
+    async with session.get(url, headers=headers) as resp:
+        if resp.status != 200:
+            return 0
+        if "Link" in resp.headers:
+            return _extract_total_from_link(resp.headers.get("Link"))
+        data = await resp.json()
+        return len(data)
 
 
 @dataclass
@@ -125,59 +90,46 @@ class RepoStats:
     merge_count: int
 
 
-async def _get_paginated_count(
-    session: aiohttp.ClientSession, url: str, headers: dict
-) -> int:
-    """Return the total item count for a paginated GitHub API endpoint."""
-    async with session.get(url, headers=headers) as resp:
-        if resp.status != 200:
-            return 0
-        if "Link" in resp.headers:
-            match = re.search(r"page=(\d+)>; rel=\"last\"", resp.headers["Link"])
-            if match:
-                return int(match.group(1))
-        data = await resp.json()
-        return len(data)
-
-
 async def gather_repo_stats() -> List[RepoStats]:
-    """Gather commit, PR and merge counts for all user repositories."""
+    """Gather commit and pull request statistics for repositories owned by the token user."""
     if not settings.github_token:
         return []
 
-    headers = {"Accept": "application/vnd.github+json", "Authorization": f"token {settings.github_token}"}
-
-    repos_url = "https://api.github.com/user/repos?per_page=100&affiliation=owner"
-    stats: List[RepoStats] = []
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"token {settings.github_token}",
+    }
+    repos_url = f"{GITHUB_API_BASE}/user/repos?per_page=100&affiliation=owner"
 
     async with aiohttp.ClientSession() as session:
         async with session.get(repos_url, headers=headers) as resp:
             if resp.status != 200:
-                return stats
+                return []
             repositories = await resp.json()
 
+        stats: List[RepoStats] = []
         for repo in repositories:
             full_name = repo.get("full_name")
             if not full_name:
                 continue
 
-            commits_url = f"https://api.github.com/repos/{full_name}/commits?per_page=1"
+            commits_url = f"{GITHUB_API_BASE}/repos/{full_name}/commits?per_page=1"
             commit_count = await _get_paginated_count(session, commits_url, headers)
 
-            prs_url = (
-                f"https://api.github.com/search/issues?q=repo:{full_name}+type:pr"
-            )
-            merges_url = (
-                f"https://api.github.com/search/issues?q=repo:{full_name}+is:pr+is:merged"
-            )
+            prs_url = f"{GITHUB_API_BASE}/search/issues?q=repo:{full_name}+type:pr"
+            merges_url = f"{GITHUB_API_BASE}/search/issues?q=repo:{full_name}+is:pr+is:merged"
 
-            async with session.get(prs_url, headers=headers) as resp:
-                pr_data = await resp.json() if resp.status == 200 else {}
-                pr_count = pr_data.get("total_count", 0)
+            pr_count = 0
+            merge_count = 0
+            async with session.get(prs_url, headers=headers) as pr_resp:
+                if pr_resp.status == 200:
+                    pr_data = await pr_resp.json()
+                    pr_count = pr_data.get("total_count", 0)
 
-            async with session.get(merges_url, headers=headers) as resp:
-                merge_data = await resp.json() if resp.status == 200 else {}
-                merge_count = merge_data.get("total_count", 0)
+            async with session.get(merges_url, headers=headers) as merge_resp:
+                if merge_resp.status == 200:
+                    merge_data = await merge_resp.json()
+                    merge_count = merge_data.get("total_count", 0)
 
             stats.append(
                 RepoStats(
@@ -190,37 +142,15 @@ async def gather_repo_stats() -> List[RepoStats]:
 
     return stats
 
-async def _fetch_total_count(
-    session: aiohttp.ClientSession,
-    url: str,
-    headers: Dict[str, str],
-    params: Dict[str, str],
-) -> int:
-    """Helper to fetch the GitHub API total_count value."""
-    try:
-        async with session.get(url, headers=headers, params=params) as resp:
-            if resp.status != 200:
-                logger.error("Failed request %s: %s", url, resp.status)
-                return 0
-            data = await resp.json()
-            return int(data.get("total_count", 0))
-    except Exception as exc:
-        logger.error("Error fetching %s: %s", url, exc)
-        return 0
 
-
-async def fetch_repo_stats() -> Tuple[List[Dict[str, int]], Dict[str, int]]:
-    """Gather commit and pull request statistics for all owned repositories."""
-
+async def fetch_repo_stats() -> Tuple[Dict[str, Dict[str, int]], Dict[str, int]]:
+    """Return commit and pull request counts for each repository owned by ``GITHUB_USERNAME``."""
     if not settings.github_username:
         raise ValueError("github_username not configured")
-
-
 
     headers = {"Accept": "application/vnd.github+json"}
     if settings.github_token:
         headers["Authorization"] = f"token {settings.github_token}"
-
 
     repos_url = f"{GITHUB_API_BASE}/users/{settings.github_username}/repos"
 
@@ -230,7 +160,7 @@ async def fetch_repo_stats() -> Tuple[List[Dict[str, int]], Dict[str, int]]:
                 raise RuntimeError(f"Failed to list repos: {resp.status}")
             repos = await resp.json()
 
-        stats: dict[str, dict[str, int]] = {}
+        stats: Dict[str, Dict[str, int]] = {}
         totals = {"commits": 0, "pull_requests": 0, "merged_pull_requests": 0}
 
         for repo in repos:
@@ -239,26 +169,22 @@ async def fetch_repo_stats() -> Tuple[List[Dict[str, int]], Dict[str, int]]:
                 continue
 
             commits_url = f"{GITHUB_API_BASE}/repos/{full_name}/commits?per_page=1"
+            commit_count = 0
             async with session.get(commits_url, headers=headers) as r:
-                commit_count = 0
                 if r.status == 200:
                     await r.json()
-                    commit_count = await _extract_total_from_link(r.headers.get("Link"))
+                    commit_count = _extract_total_from_link(r.headers.get("Link"))
 
-            pulls_url = (
-                f"{GITHUB_API_BASE}/repos/{full_name}/pulls?state=all&per_page=1"
-            )
+            pulls_url = f"{GITHUB_API_BASE}/repos/{full_name}/pulls?state=all&per_page=1"
+            pr_count = 0
             async with session.get(pulls_url, headers=headers) as r:
-                pr_count = 0
                 if r.status == 200:
                     await r.json()
-                    pr_count = await _extract_total_from_link(r.headers.get("Link"))
+                    pr_count = _extract_total_from_link(r.headers.get("Link"))
 
-            search_url = (
-                f"{GITHUB_API_BASE}/search/issues?q=repo:{full_name}+is:pr+is:merged&per_page=1"
-            )
+            search_url = f"{GITHUB_API_BASE}/search/issues?q=repo:{full_name}+is:pr+is:merged&per_page=1"
+            merged_count = 0
             async with session.get(search_url, headers=headers) as r:
-                merged_count = 0
                 if r.status == 200:
                     data = await r.json()
                     merged_count = int(data.get("total_count", 0))
@@ -274,134 +200,3 @@ async def fetch_repo_stats() -> Tuple[List[Dict[str, int]], Dict[str, int]]:
             totals["merged_pull_requests"] += merged_count
 
     return stats, totals
-
-
-    async with aiohttp.ClientSession() as session:
-        async with session.get(
-            "https://api.github.com/user/repos",
-            headers=headers,
-            params={"per_page": 100, "affiliation": "owner"},
-        ) as resp:
-            if resp.status != 200:
-                logger.error(f"Failed to fetch repositories: {resp.status}")
-                return []
-            repos = await resp.json()
-
-        results: List[RepoStats] = []
-        for repo in repos:
-            full_name = repo.get("full_name")
-            name = repo.get("name")
-
-            # Commit count
-            commits_url = f"https://api.github.com/repos/{full_name}/commits"
-            async with session.get(commits_url, headers=headers, params={"per_page": 1}) as c_resp:
-                if c_resp.status == 200:
-                    link = c_resp.headers.get("Link")
-                    if link and "page=" in link:
-                        last = link.split(",")[-1]
-                        commit_count = int(last.split("page=")[-1].split("&")[0])
-                    else:
-                        data = await c_resp.json()
-                        commit_count = len(data)
-                else:
-                    commit_count = 0
-
-            # PR count
-            pr_url = "https://api.github.com/search/issues"
-            async with session.get(
-                pr_url,
-                headers=headers,
-                params={"q": f"repo:{full_name} is:pr", "per_page": 1},
-            ) as pr_resp:
-                if pr_resp.status == 200:
-                    data = await pr_resp.json()
-                    pr_count = data.get("total_count", 0)
-                else:
-                    pr_count = 0
-
-            # Merge count
-            async with session.get(
-                pr_url,
-                headers=headers,
-                params={"q": f"repo:{full_name} is:pr is:merged", "per_page": 1},
-            ) as merge_resp:
-                if merge_resp.status == 200:
-                    data = await merge_resp.json()
-                    merge_count = data.get("total_count", 0)
-                else:
-                    merge_count = 0
-
-            results.append(RepoStats(name, commit_count, pr_count, merge_count))
-
-    return results
-
-    commit_headers = {
-        "Accept": "application/vnd.github.cloak-preview+json",
-    }
-    if settings.github_token:
-        commit_headers["Authorization"] = f"token {settings.github_token}"
-
-    repo_stats: List[Dict[str, int]] = []
-    totals = {
-        "commits": 0,
-        "pull_requests": 0,
-        "merged_pull_requests": 0,
-    }
-
-    async with aiohttp.ClientSession() as session:
-        repos: List[Dict[str, str]] = []
-        page = 1
-        while True:
-            params = {"per_page": "100", "type": "owner", "page": str(page)}
-            url = f"{GITHUB_API_BASE}/user/repos"
-            async with session.get(url, headers=headers, params=params) as resp:
-                if resp.status != 200:
-                    logger.error("Failed to list repositories: %s", resp.status)
-                    break
-                data = await resp.json()
-                if not data:
-                    break
-                repos.extend(data)
-                page += 1
-
-        for repo in repos:
-            name = repo.get("full_name")
-            if not name:
-                continue
-
-            commit_count = await _fetch_total_count(
-                session,
-                f"{GITHUB_API_BASE}/search/commits",
-                commit_headers,
-                {"q": f"repo:{name}"},
-            )
-            pr_count = await _fetch_total_count(
-                session,
-                f"{GITHUB_API_BASE}/search/issues",
-                headers,
-                {"q": f"repo:{name}+type:pr"},
-            )
-            merged_pr_count = await _fetch_total_count(
-                session,
-                f"{GITHUB_API_BASE}/search/issues",
-                headers,
-                {"q": f"repo:{name}+type:pr+is:merged"},
-            )
-
-            repo_stats.append(
-                {
-                    "name": name,
-                    "commits": commit_count,
-                    "pull_requests": pr_count,
-                    "merged_pull_requests": merged_pr_count,
-                }
-            )
-
-            totals["commits"] += commit_count
-            totals["pull_requests"] += pr_count
-            totals["merged_pull_requests"] += merged_pr_count
-
-    return repo_stats, totals
-
-
-


### PR DESCRIPTION
## Summary
- remove duplicate imports and definitions in `github_utils.py`
- keep one documented `RepoStats` dataclass and helper implementations
- ensure all helper functions return type hints

## Testing
- `python -m py_compile github_utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp', SyntaxError in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_6870020d82f88332b31451051a507aec