### PR TITLE
Add configurable agent base directory

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -12,6 +12,9 @@ WEBHOOK_URL=http://65.21.253.0:8000/github
 HOST=0.0.0.0
 PORT=8000
 
+# Base directory for agent logs and state
+AGENTS_BASE_DIR=/home/youruser/Agents
+
 # Discord Channel IDs (from AGENTS.md)
 
 CHANNEL_COMMITS=1392467209162592266

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/your_webhook_id/your_web
 You can control how long messages stay in key channels by setting `MESSAGE_RETENTION_DAYS`.
 If not set, messages older than 30 days are removed.
 
+Log and state files are stored under a canonical agents directory. By default this
+is `~/Agents`, but you can change it with `AGENTS_BASE_DIR`:
+
+```ini
+AGENTS_BASE_DIR=/path/to/custom/Agents
+```
+
 
 The bot posts messages to multiple Discord channels. Override their IDs in `.env` if your server uses different channels:
 

--- a/agents_config.py
+++ b/agents_config.py
@@ -3,8 +3,11 @@
 from pathlib import Path
 import os
 
-# AGENTS.MD compliant canonical directory
-AGENTS_CANONICAL_DIR = Path("/home/cinder/Documents/Agents")
+# AGENTS.MD compliant canonical directory. Use AGENTS_BASE_DIR env var if set
+# otherwise default to ~/Agents.
+AGENTS_CANONICAL_DIR = Path(
+    os.environ.get("AGENTS_BASE_DIR", str(Path.home() / "Agents"))
+).expanduser()
 
 # Subdirectories
 AGENTS_LOGS_DIR = AGENTS_CANONICAL_DIR / "logs"
@@ -22,7 +25,11 @@ def ensure_agents_directories():
         AGENTS_CONFIG_DIR,
         AGENTS_SHARED_DIR,
     ]:
-        directory.mkdir(parents=True, exist_ok=True)
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            # Skip if we can't create the directory
+            continue
 
         # Set permissions to allow deploy user to write
         try:

--- a/config.py
+++ b/config.py
@@ -49,6 +49,7 @@ class Settings(BaseSettings):
     message_retention_days: int = 30
 
     # Agent compliance paths
+    agents_base_dir: str = str(AGENTS_CANONICAL_DIR)
     logs_directory: str = str(LOGS_DIR)
     state_directory: str = str(STATE_DIR)
     agent_metadata: dict = AGENT_METADATA

--- a/logging_config.py
+++ b/logging_config.py
@@ -3,15 +3,22 @@
 import logging
 import logging.handlers
 from pathlib import Path
+import os
 
-# Canonical directory for agent logs and state
-AGENTS_DIR = Path("/home/cinder/Documents/Agents")
+# Canonical directory for agent logs and state. Use AGENTS_BASE_DIR env var if
+# available, otherwise default to ~/Agents.
+AGENTS_DIR = Path(
+    os.environ.get("AGENTS_BASE_DIR", str(Path.home() / "Agents"))
+).expanduser()
 LOGS_DIR = AGENTS_DIR / "logs"
 STATE_DIR = AGENTS_DIR / "state"
 
-# Ensure directories exist
-LOGS_DIR.mkdir(parents=True, exist_ok=True)
-STATE_DIR.mkdir(parents=True, exist_ok=True)
+# Ensure directories exist and ignore permission errors
+for _dir in (LOGS_DIR, STATE_DIR):
+    try:
+        _dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        continue
 
 
 def setup_logging():


### PR DESCRIPTION
## Summary
- allow specifying `AGENTS_BASE_DIR` for agents directory
- include base dir in application settings
- update logging configuration to respect the environment variable
- document `AGENTS_BASE_DIR` and add to `.env.template`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError during tests)*

------
https://chatgpt.com/codex/tasks/task_e_687001ec6d208332a2d7aab407341b8a