### PR TITLE
Clean up repo stats utils

### DIFF
--- a/github_utils.py
+++ b/github_utils.py
@@ -3,27 +3,14 @@
 import hashlib
 import hmac
 import logging
-
-from dataclasses import dataclass
-from typing import Optional, List
-
-import aiohttp
-from fastapi import Request, HTTPException
-
-from typing import Optional, List, Dict, Tuple
-
-import aiohttp
-from fastapi import Request, HTTPException
-from typing import Optional, List
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
 import aiohttp
-
-
+from fastapi import HTTPException, Request
 
 from config import settings
-
-logger = logging.getLogger(__name__)
 
 
 logger = logging.getLogger(__name__)
@@ -43,26 +30,21 @@ async def verify_github_signature(request: Request, body: bytes) -> None:
             status_code=401, detail="Missing X-Hub-Signature-256 header"
         )
 
-    # Calculate the expected signature
     expected_signature = hmac.new(
         settings.github_webhook_secret.encode("utf-8"), body, hashlib.sha256
     ).hexdigest()
-
-    # GitHub prefixes the signature with "sha256="
     expected_signature = f"sha256={expected_signature}"
 
-    # Compare signatures
     if not hmac.compare_digest(signature, expected_signature):
         raise HTTPException(status_code=401, detail="Invalid signature")
 
 
 def is_github_event_relevant(event_type: str, payload: dict) -> bool:
     """Check if the GitHub event is relevant and should be processed."""
-    # Skip some events that might be too noisy
     skip_actions = {
         "pull_request": ["synchronize", "edited", "review_requested"],
         "issues": ["edited", "labeled", "unlabeled"],
-        "push": [],  # Process all push events
+        "push": [],
     }
 
     if event_type in skip_actions:
@@ -71,48 +53,6 @@ def is_github_event_relevant(event_type: str, payload: dict) -> bool:
             return False
 
     return True
-
-
-import aiohttp
-
-GITHUB_API_BASE = "https://api.github.com"
-
-
-async def _extract_total_from_link(link_header: Optional[str]) -> int:
-    """Extract the last page number from a GitHub pagination link header."""
-    if not link_header or "rel=\"last\"" not in link_header:
-        return 1
-    for part in link_header.split(','):
-        if 'rel="last"' in part:
-            url_part = part.split(';')[0].strip('<> ')
-            if "page=" in url_part:
-                try:
-                    return int(url_part.split("page=")[-1].split("&")[0])
-                except ValueError:
-                    return 1
-    return 1
-
-
-async def fetch_repo_stats() -> tuple[dict[str, dict[str, int]], dict[str, int]]:
-    """Fetch commit and pull request stats for all repos owned by the user."""
-    if not settings.github_username:
-        raise ValueError("github_username not configured")
-
-
-
-
-@dataclass
-class RepoStats:
-    """Statistics for a single repository."""
-
-    name: str
-    commits: int
-    pull_requests: int
-    merges: int
-
-
-async def gather_repo_stats() -> List[RepoStats]:
-    """Gather commit, PR and merge counts for each repository."""
 
 
 @dataclass
@@ -126,7 +66,7 @@ class RepoStats:
 
 
 async def _get_paginated_count(
-    session: aiohttp.ClientSession, url: str, headers: dict
+    session: aiohttp.ClientSession, url: str, headers: Dict[str, str]
 ) -> int:
     """Return the total item count for a paginated GitHub API endpoint."""
     async with session.get(url, headers=headers) as resp:
@@ -145,9 +85,12 @@ async def gather_repo_stats() -> List[RepoStats]:
     if not settings.github_token:
         return []
 
-    headers = {"Accept": "application/vnd.github+json", "Authorization": f"token {settings.github_token}"}
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"token {settings.github_token}",
+    }
 
-    repos_url = "https://api.github.com/user/repos?per_page=100&affiliation=owner"
+    repos_url = f"{GITHUB_API_BASE}/user/repos?per_page=100&affiliation=owner"
     stats: List[RepoStats] = []
 
     async with aiohttp.ClientSession() as session:
@@ -161,14 +104,14 @@ async def gather_repo_stats() -> List[RepoStats]:
             if not full_name:
                 continue
 
-            commits_url = f"https://api.github.com/repos/{full_name}/commits?per_page=1"
+            commits_url = f"{GITHUB_API_BASE}/repos/{full_name}/commits?per_page=1"
             commit_count = await _get_paginated_count(session, commits_url, headers)
 
             prs_url = (
-                f"https://api.github.com/search/issues?q=repo:{full_name}+type:pr"
+                f"{GITHUB_API_BASE}/search/issues?q=repo:{full_name}+type:pr"
             )
             merges_url = (
-                f"https://api.github.com/search/issues?q=repo:{full_name}+is:pr+is:merged"
+                f"{GITHUB_API_BASE}/search/issues?q=repo:{full_name}+is:pr+is:merged"
             )
 
             async with session.get(prs_url, headers=headers) as resp:
@@ -190,6 +133,7 @@ async def gather_repo_stats() -> List[RepoStats]:
 
     return stats
 
+
 async def _fetch_total_count(
     session: aiohttp.ClientSession,
     url: str,
@@ -204,157 +148,34 @@ async def _fetch_total_count(
                 return 0
             data = await resp.json()
             return int(data.get("total_count", 0))
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - network failure
         logger.error("Error fetching %s: %s", url, exc)
         return 0
 
 
 async def fetch_repo_stats() -> Tuple[List[Dict[str, int]], Dict[str, int]]:
     """Gather commit and pull request statistics for all owned repositories."""
-
     if not settings.github_username:
         raise ValueError("github_username not configured")
-
-
 
     headers = {"Accept": "application/vnd.github+json"}
     if settings.github_token:
         headers["Authorization"] = f"token {settings.github_token}"
 
-
-    repos_url = f"{GITHUB_API_BASE}/users/{settings.github_username}/repos"
-
-    async with aiohttp.ClientSession() as session:
-        async with session.get(repos_url, headers=headers) as resp:
-            if resp.status != 200:
-                raise RuntimeError(f"Failed to list repos: {resp.status}")
-            repos = await resp.json()
-
-        stats: dict[str, dict[str, int]] = {}
-        totals = {"commits": 0, "pull_requests": 0, "merged_pull_requests": 0}
-
-        for repo in repos:
-            full_name = repo.get("full_name")
-            if not full_name:
-                continue
-
-            commits_url = f"{GITHUB_API_BASE}/repos/{full_name}/commits?per_page=1"
-            async with session.get(commits_url, headers=headers) as r:
-                commit_count = 0
-                if r.status == 200:
-                    await r.json()
-                    commit_count = await _extract_total_from_link(r.headers.get("Link"))
-
-            pulls_url = (
-                f"{GITHUB_API_BASE}/repos/{full_name}/pulls?state=all&per_page=1"
-            )
-            async with session.get(pulls_url, headers=headers) as r:
-                pr_count = 0
-                if r.status == 200:
-                    await r.json()
-                    pr_count = await _extract_total_from_link(r.headers.get("Link"))
-
-            search_url = (
-                f"{GITHUB_API_BASE}/search/issues?q=repo:{full_name}+is:pr+is:merged&per_page=1"
-            )
-            async with session.get(search_url, headers=headers) as r:
-                merged_count = 0
-                if r.status == 200:
-                    data = await r.json()
-                    merged_count = int(data.get("total_count", 0))
-
-            stats[full_name] = {
-                "commits": commit_count,
-                "pull_requests": pr_count,
-                "merged_pull_requests": merged_count,
-            }
-
-            totals["commits"] += commit_count
-            totals["pull_requests"] += pr_count
-            totals["merged_pull_requests"] += merged_count
-
-    return stats, totals
-
-
-    async with aiohttp.ClientSession() as session:
-        async with session.get(
-            "https://api.github.com/user/repos",
-            headers=headers,
-            params={"per_page": 100, "affiliation": "owner"},
-        ) as resp:
-            if resp.status != 200:
-                logger.error(f"Failed to fetch repositories: {resp.status}")
-                return []
-            repos = await resp.json()
-
-        results: List[RepoStats] = []
-        for repo in repos:
-            full_name = repo.get("full_name")
-            name = repo.get("name")
-
-            # Commit count
-            commits_url = f"https://api.github.com/repos/{full_name}/commits"
-            async with session.get(commits_url, headers=headers, params={"per_page": 1}) as c_resp:
-                if c_resp.status == 200:
-                    link = c_resp.headers.get("Link")
-                    if link and "page=" in link:
-                        last = link.split(",")[-1]
-                        commit_count = int(last.split("page=")[-1].split("&")[0])
-                    else:
-                        data = await c_resp.json()
-                        commit_count = len(data)
-                else:
-                    commit_count = 0
-
-            # PR count
-            pr_url = "https://api.github.com/search/issues"
-            async with session.get(
-                pr_url,
-                headers=headers,
-                params={"q": f"repo:{full_name} is:pr", "per_page": 1},
-            ) as pr_resp:
-                if pr_resp.status == 200:
-                    data = await pr_resp.json()
-                    pr_count = data.get("total_count", 0)
-                else:
-                    pr_count = 0
-
-            # Merge count
-            async with session.get(
-                pr_url,
-                headers=headers,
-                params={"q": f"repo:{full_name} is:pr is:merged", "per_page": 1},
-            ) as merge_resp:
-                if merge_resp.status == 200:
-                    data = await merge_resp.json()
-                    merge_count = data.get("total_count", 0)
-                else:
-                    merge_count = 0
-
-            results.append(RepoStats(name, commit_count, pr_count, merge_count))
-
-    return results
-
-    commit_headers = {
-        "Accept": "application/vnd.github.cloak-preview+json",
-    }
+    commit_headers = {"Accept": "application/vnd.github.cloak-preview+json"}
     if settings.github_token:
         commit_headers["Authorization"] = f"token {settings.github_token}"
 
+    repos_url = f"{GITHUB_API_BASE}/user/repos"
     repo_stats: List[Dict[str, int]] = []
-    totals = {
-        "commits": 0,
-        "pull_requests": 0,
-        "merged_pull_requests": 0,
-    }
+    totals = {"commits": 0, "pull_requests": 0, "merged_pull_requests": 0}
 
     async with aiohttp.ClientSession() as session:
         repos: List[Dict[str, str]] = []
         page = 1
         while True:
             params = {"per_page": "100", "type": "owner", "page": str(page)}
-            url = f"{GITHUB_API_BASE}/user/repos"
-            async with session.get(url, headers=headers, params=params) as resp:
+            async with session.get(repos_url, headers=headers, params=params) as resp:
                 if resp.status != 200:
                     logger.error("Failed to list repositories: %s", resp.status)
                     break
@@ -402,6 +223,4 @@ async def fetch_repo_stats() -> Tuple[List[Dict[str, int]], Dict[str, int]]:
             totals["merged_pull_requests"] += merged_pr_count
 
     return repo_stats, totals
-
-
 

--- a/main.py
+++ b/main.py
@@ -1,35 +1,15 @@
 """Main server endpoint for receiving GitHub webhooks with enhanced PR handling."""
 
-import logging
 import asyncio
+import logging
+
 import discord
-from fastapi import FastAPI, Request, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from logging_config import setup_logging
-from config import settings
-import discord
-from discord_bot import send_to_discord, discord_bot_instance
-from pull_request_handler import handle_pull_request_event_with_retry
-
 from cleanup import cleanup_pr_messages
-
-
-from pr_map import load_pr_map, save_pr_map
-from github_utils import (
-    verify_github_signature,
-    is_github_event_relevant,
-    gather_repo_stats,
-
-    RepoStats,
-)
-
-)
-
-from github_utils import verify_github_signature, is_github_event_relevant
-from github_stats import fetch_repo_stats
-from stats_map import load_stats_map, save_stats_map
-
+from config import settings
+from discord_bot import discord_bot_instance, send_to_discord
 from formatters import (
     format_push_event,
     format_issue_event,
@@ -42,6 +22,17 @@ from formatters import (
     format_check_suite,
     format_generic_event,
 )
+from github_stats import fetch_repo_stats
+from github_utils import (
+    verify_github_signature,
+    is_github_event_relevant,
+    gather_repo_stats,
+    RepoStats,
+)
+from logging_config import setup_logging
+from pr_map import load_pr_map, save_pr_map
+from pull_request_handler import handle_pull_request_event_with_retry
+from stats_map import load_stats_map, save_stats_map
 
 # Setup logging
 setup_logging()
@@ -230,20 +221,12 @@ async def update_statistics() -> None:
         logger.error(f"Failed to gather repo stats: {exc}")
         return
 
-    total_commits = sum(s.commits for s in stats)
-    total_prs = sum(s.pull_requests for s in stats)
-    total_merges = sum(s.merges for s in stats)
-
-    """Update channel names and send repository statistics embeds."""
     while not discord_bot_instance.ready:
         await asyncio.sleep(1)
-
-    stats = await gather_repo_stats()
 
     total_commits = sum(r.commit_count for r in stats)
     total_prs = sum(r.pr_count for r in stats)
     total_merges = sum(r.merge_count for r in stats)
-
 
     await discord_bot_instance.update_channel_name(
         settings.channel_commits, f"{total_commits}-commits"
@@ -257,23 +240,12 @@ async def update_statistics() -> None:
 
     for repo in stats:
         embed = discord.Embed(
-
-            title=repo.name,
-            color=discord.Color.blue(),
-        )
-        embed.add_field(name="Commits", value=str(repo.commits), inline=True)
-        embed.add_field(
-            name="Pull Requests", value=str(repo.pull_requests), inline=True
-        )
-        embed.add_field(name="Merges", value=str(repo.merges), inline=True)
-
             title=f"📊 Statistics for {repo.name}",
             color=discord.Color.blue(),
         )
         embed.add_field(name="Commits", value=str(repo.commit_count), inline=True)
         embed.add_field(name="Pull Requests", value=str(repo.pr_count), inline=True)
         embed.add_field(name="Merges", value=str(repo.merge_count), inline=True)
-
 
         await send_to_discord(settings.channel_commits, embed=embed)
         await send_to_discord(settings.channel_pull_requests, embed=embed)

--- a/tests/test_github_utils.py
+++ b/tests/test_github_utils.py
@@ -2,92 +2,140 @@ import asyncio
 import os
 import sys
 import unittest
-from unittest import mock
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
 os.environ.setdefault("GITHUB_USERNAME", "alice")
+os.environ.setdefault("GITHUB_TOKEN", "token")
 
 import github_utils
 from config import settings
 
 
-class MockResp:
-    def __init__(self, status: int, data=None, headers=None):
-        self.status = status
-        self._data = data or {}
-        self.headers = headers or {}
-
-    async def json(self):
-        return self._data
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        pass
-
-
-class MockSession:
-    def __init__(self, responses):
-        self._responses = responses
-
-    def get(self, url, headers=None):
-        return self._responses.pop(0)
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        pass
-
-
 class TestFetchRepoStats(unittest.TestCase):
-    def setUp(self):
-        patcher = mock.patch.object(settings, "github_username", "alice")
-        patcher.start()
-        self.addCleanup(patcher.stop)
+    def setUp(self) -> None:
+        patcher1 = mock.patch.object(settings, "github_username", "alice")
+        patcher1.start()
+        self.addCleanup(patcher1.stop)
+        patcher2 = mock.patch.object(settings, "github_token", "token")
+        patcher2.start()
+        self.addCleanup(patcher2.stop)
+
+    def _mock_session(self):
+        class MockResponse:
+            def __init__(self, data, status=200):
+                self.data = data
+                self.status = status
+
+            async def json(self):
+                return self.data
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+        class MockSession:
+            def get(self, url, headers=None, params=None):
+                if url.endswith("/user/repos"):
+                    page = int(params.get("page", 1)) if params else 1
+                    if page == 1:
+                        return MockResponse([
+                            {"full_name": "alice/repo1"},
+                            {"full_name": "alice/repo2"},
+                        ])
+                    return MockResponse([])
+                if url.endswith("/search/commits"):
+                    repo = params["q"].split("repo:")[1]
+                    count = {"alice/repo1": 5, "alice/repo2": 10}[repo]
+                    return MockResponse({"total_count": count})
+                if url.endswith("/search/issues"):
+                    repo = params["q"].split("repo:")[1].split("+")[0]
+                    if "is:merged" in params["q"]:
+                        count = {"alice/repo1": 2, "alice/repo2": 4}[repo]
+                    else:
+                        count = {"alice/repo1": 3, "alice/repo2": 7}[repo]
+                    return MockResponse({"total_count": count})
+                return MockResponse({}, status=404)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+        return MockSession()
+
+    def _mock_session_missing(self):
+        class MockResponse:
+            def __init__(self, data, status=200):
+                self.data = data
+                self.status = status
+
+            async def json(self):
+                return self.data
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+        class MockSession:
+            def get(self, url, headers=None, params=None):
+                if url.endswith("/user/repos"):
+                    page = int(params.get("page", 1)) if params else 1
+                    if page == 1:
+                        return MockResponse([{"full_name": "alice/repo1"}])
+                    return MockResponse([])
+                if url.endswith("/search/commits"):
+                    return MockResponse({"total_count": 0})
+                if url.endswith("/search/issues"):
+                    if "is:merged" in params["q"]:
+                        return MockResponse({"total_count": 0})
+                    return MockResponse({"total_count": 1})
+                return MockResponse({}, status=404)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+        return MockSession()
 
     def test_fetch_repo_stats_success(self):
-        responses = [
-            MockResp(200, [{"full_name": "alice/repo1"}, {"full_name": "alice/repo2"}]),
-            MockResp(200, [], {"Link": "<x?page=5>; rel=\"last\""}),
-            MockResp(200, [], {"Link": "<x?page=3>; rel=\"last\""}),
-            MockResp(200, {"total_count": 2}),
-            MockResp(200, [], {"Link": "<x?page=10>; rel=\"last\""}),
-            MockResp(200, [], {"Link": "<x?page=7>; rel=\"last\""}),
-            MockResp(200, {"total_count": 4}),
-        ]
-        mock_session = MockSession(responses)
+        mock_session = self._mock_session()
         with mock.patch("github_utils.aiohttp.ClientSession", return_value=mock_session):
             stats, totals = asyncio.run(github_utils.fetch_repo_stats())
 
-        expected = {
-            "alice/repo1": {"commits": 5, "pull_requests": 3, "merged_pull_requests": 2},
-            "alice/repo2": {"commits": 10, "pull_requests": 7, "merged_pull_requests": 4},
-        }
-        self.assertEqual(stats, expected)
-        self.assertEqual(totals, {"commits": 15, "pull_requests": 10, "merged_pull_requests": 6})
+        expected_stats = [
+            {"name": "alice/repo1", "commits": 5, "pull_requests": 3, "merged_pull_requests": 2},
+            {"name": "alice/repo2", "commits": 10, "pull_requests": 7, "merged_pull_requests": 4},
+        ]
+        expected_totals = {"commits": 15, "pull_requests": 10, "merged_pull_requests": 6}
+
+        self.assertEqual(stats, expected_stats)
+        self.assertEqual(totals, expected_totals)
 
     def test_fetch_repo_stats_missing_data(self):
-        responses = [
-            MockResp(200, [{"full_name": "alice/repo1"}]),
-            MockResp(404),
-            MockResp(200, []),
-            MockResp(200, {"total_count": 0}),
-        ]
-        mock_session = MockSession(responses)
+        mock_session = self._mock_session_missing()
         with mock.patch("github_utils.aiohttp.ClientSession", return_value=mock_session):
             stats, totals = asyncio.run(github_utils.fetch_repo_stats())
 
-        self.assertEqual(
-            stats,
-            {"alice/repo1": {"commits": 0, "pull_requests": 1, "merged_pull_requests": 0}},
-        )
-        self.assertEqual(totals, {"commits": 0, "pull_requests": 1, "merged_pull_requests": 0})
+        expected_stats = [
+            {"name": "alice/repo1", "commits": 0, "pull_requests": 1, "merged_pull_requests": 0}
+        ]
+        expected_totals = {"commits": 0, "pull_requests": 1, "merged_pull_requests": 0}
+
+        self.assertEqual(stats, expected_stats)
+        self.assertEqual(totals, expected_totals)
 
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- remove duplicate import blocks and clean up code in `github_utils.py` and `main.py`
- keep one implementation of `gather_repo_stats` and helpers
- update `fetch_repo_stats` tests for new return structure

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_github_utils.py::TestFetchRepoStats::test_fetch_repo_stats_success -q` *(fails: Pydantic config error)*

------
https://chatgpt.com/codex/tasks/task_e_687001f89d7c83329bf946f80308f199