### PR TITLE
Add environment setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Codex environment setup script for the Discord GitHub Bot project.
+# This script creates a Python virtual environment and installs the
+# dependencies required for running the bot and its tests.
+
+set -euo pipefail
+
+# Create virtual environment if it does not already exist
+if [ ! -d ".venv" ]; then
+    python -m venv .venv
+fi
+
+# Activate the virtual environment
+source .venv/bin/activate
+
+# Upgrade pip and install Python dependencies
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m pip install pytest
+
+# Create a default .env if none exists
+if [ ! -f .env ] && [ -f .env.template ]; then
+    cp .env.template .env
+    echo "Created .env from template. Update it with your configuration."
+fi
+
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- add `setup.sh` to prepare a local Codex environment

## Testing
- `pytest -q` *(fails: IndentationError in code and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6870080e4a58833280bd3af7dd7a168d