### PR TITLE
Fix duplicated channel ID defaults

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,10 +24,6 @@ class Settings(BaseSettings):
     port: int = 8000
 
     # Discord Channel IDs
-    channel_commits: int = 1392467209162592266
-    channel_pull_requests: int = 1392467228624158730
-    channel_code_merges: int = 1392467252711919666
-
     channel_commits: int = 1392213436720615504
     channel_pull_requests: int = 1392485974398861354
     channel_code_merges: int = 1392213492156727387
@@ -41,9 +37,6 @@ class Settings(BaseSettings):
     channel_ci_builds: int = 1392457950169268334
     channel_gollum: int = 1392213582963540028
     channel_bot_logs: int = 1392213610167664670
-    channel_commits_overview: int = 1392467209162592266
-    channel_pull_requests_overview: int = 1392467228624158730
-    channel_merges_overview: int = 1392467252711919666
 
     # Message retention configuration
     message_retention_days: int = 30
@@ -53,12 +46,7 @@ class Settings(BaseSettings):
     state_directory: str = str(STATE_DIR)
     agent_metadata: dict = AGENT_METADATA
  
-    model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
-
-
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
 
 


### PR DESCRIPTION
## Summary
- drop duplicate channel ID assignments in `config.py`
- load `.env` even if extra variables exist

## Testing
- `python - <<'PY'
from config import Settings
s = Settings()
print('commits', s.channel_commits)
print('pull_requests', s.channel_pull_requests)
PY
`
- `pytest -q` *(fails: ModuleNotFoundError & syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68701f708cdc8332942b5ed024afc20c