### PR TITLE
Fix duplicate functions in discord bot

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -150,25 +150,7 @@ class DiscordBot:
                 pass
 
     async def update_channel_name(self, channel_id: int, new_name: str) -> bool:
-
         """Rename a Discord channel."""
-
-
-        """Rename a Discord channel."""
-        if not self.ready:
-            await self.bot.wait_until_ready()
-        channel = self.bot.get_channel(channel_id)
-        if not channel:
-            logger.error(f"Channel {channel_id} not found for renaming")
-            return False
-        try:
-
-
-        """Update the name of a Discord channel."""
-
-        """Rename a Discord channel."""
-
-
         if not self.ready:
             await self.bot.wait_until_ready()
 
@@ -177,39 +159,6 @@ class DiscordBot:
             if not channel:
                 logger.error(f"Channel {channel_id} not found for rename")
                 return False
-
-            await channel.edit(name=new_name)
-            return True
-        except Exception as e:
-            logger.error(f"Failed to rename channel {channel_id} to {new_name}: {e}")
-
-
-
-
-            await channel.edit(name=new_name)
-            return True
-        except Exception as e:
-            logger.error(f"Failed to rename channel {channel_id}: {e}")
-
-
-            try:
-                logs_channel = self.bot.get_channel(settings.channel_bot_logs)
-                if logs_channel:
-                    await logs_channel.send(f"❌ Failed to rename channel {channel_id}: {e}")
-            except Exception:
-                pass
-
-            return False
-
-
-        return False
-
-            return False
-
-
-
-    async def send_to_webhook(self, url: str, content: str = None, embed: discord.Embed = None):
-
             await channel.edit(name=new_name)
             return True
         except Exception as e:
@@ -221,6 +170,8 @@ class DiscordBot:
             except Exception:
                 pass
             return False
+
+
 
     async def send_to_webhook(
         self, url: str, content: str = None, embed: discord.Embed = None
@@ -408,56 +359,6 @@ async def update(ctx: commands.Context) -> None:
     await ctx.send("Pull request channel updated.")
 
 
-@bot.command(name="clear")
-async def clear(ctx: commands.Context) -> None:
-    """Clear all development-related channels."""
-
-
-@bot.command(name="update")
-async def update(ctx: commands.Context) -> None:
-    """Send embeds for all open pull requests."""
-    prs_by_repo = await fetch_open_pull_requests()
-    for repo, prs in prs_by_repo.items():
-        for pr in prs:
-            payload = {
-                "action": "opened",
-                "pull_request": pr,
-                "repository": {"full_name": repo},
-            }
-            embed = format_pull_request_event(payload)
-            await send_to_discord(settings.channel_pull_requests, embed=embed)
-
-@bot.command(name="clear")
-async def clear_channels(ctx: commands.Context) -> None:
-
-    """Clear all messages from development channels."""
-    for channel_id in DEV_CHANNELS:
-        await discord_bot_instance.purge_old_messages(channel_id, 0)
-    await ctx.send("✅ Channels cleared.")
-
-    """Clear development-related Discord channels."""
-    channels = [
-        settings.channel_commits,
-        settings.channel_pull_requests,
-        settings.channel_releases,
-        settings.channel_ci_builds,
-        settings.channel_code_merges,
-    ]
-
-    await asyncio.gather(
-        *(discord_bot_instance.purge_old_messages(ch, 0) for ch in channels)
-    )
-
-    await ctx.send("Development channels cleared.")
-
-        settings.channel_code_merges,
-        settings.channel_ci_builds,
-        settings.channel_deployment_status,
-        settings.channel_gollum,
-    ]
-    for chan in channels:
-        await discord_bot_instance.purge_channel(chan)
-    await ctx.send("Development channels cleared.")
 
 
 @bot.command(name="update")


### PR DESCRIPTION
## Summary
- remove stray duplicate code in `discord_bot.py`
- keep a single implementation for `update_channel_name` and `send_to_webhook`
- clean up duplicate command blocks

## Testing
- `python -m py_compile discord_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68701f6c7600833295bd79ea12e35247