### PR TITLE
Update README with setup script usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ See the [Channel mapping](docs/ChannelMapping.md) document for routing details.
    python run.py
    ```
 
+For a quicker start you can run the helper script:
+
+```bash
+./setup.sh
+```
+
+It installs all dependencies inside `.venv` and copies `.env.template` to `.env`
+if needed. See **AGENTS.md** for guidelines on keeping this script current.
+
 ### Environment Variables
 
 


### PR DESCRIPTION
## Summary
- document running `./setup.sh` for dependency install and `.env` creation

## Testing
- `./setup.sh`
- `pytest -q` *(fails: CommandRegistrationError in discord_bot)*

------
https://chatgpt.com/codex/tasks/task_e_68702d4d007083328f308a842f60dc54