### PR TITLE
Replace hardcoded paths with env vars

### DIFF
--- a/discord-github-bot.service
+++ b/discord-github-bot.service
@@ -4,13 +4,17 @@ After=network.target network-online.target
 Wants=network-online.target
 
 [Service]
+# Set DISCORD_GITHUB_HOME to the installation directory of the bot.
+# When deploying, update the path below or override the variable via an
+# EnvironmentFile.
+Environment=DISCORD_GITHUB_HOME=/opt/discord-github
 Type=simple
 User=cinder
 Group=cinder
-WorkingDirectory=/home/cinder/Documents/D_Projects/Discord-Github
-Environment=PATH=/home/cinder/Documents/D_Projects/Discord-Github/.venv/bin
-EnvironmentFile=-/home/cinder/Documents/D_Projects/Discord-Github/.env
-ExecStart=/home/cinder/Documents/D_Projects/Discord-Github/.venv/bin/python run.py
+WorkingDirectory=${DISCORD_GITHUB_HOME}
+Environment=PATH=${DISCORD_GITHUB_HOME}/.venv/bin
+EnvironmentFile=-${DISCORD_GITHUB_HOME}/.env
+ExecStart=${DISCORD_GITHUB_HOME}/.venv/bin/python run.py
 Restart=always
 RestartSec=10
 KillMode=mixed
@@ -18,7 +22,7 @@ KillSignal=SIGINT
 TimeoutStopSec=30
 PrivateTmp=true
 ProtectSystem=strict
-ReadWritePaths=/home/cinder/Documents/D_Projects/Discord-Github
+ReadWritePaths=${DISCORD_GITHUB_HOME}
 NoNewPrivileges=true
 StandardOutput=journal
 StandardError=journal

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,16 +1,20 @@
+// Set DISCORD_GITHUB_HOME to the installation directory of the bot.
+// When deploying, export the variable or edit the fallback path below.
+const BASE = process.env.DISCORD_GITHUB_HOME || '/opt/discord-github';
+
 module.exports = {
   apps: [{
     name: 'discord-github-bot',
     script: 'run.py',
-    interpreter: '/home/cinder/Documents/D_Projects/Discord-Github/.venv/bin/python',
-    cwd: '/home/cinder/Documents/D_Projects/Discord-Github',
+    interpreter: `${BASE}/.venv/bin/python`,
+    cwd: BASE,
     instances: 1,
     autorestart: true,
     watch: false,
     max_memory_restart: '1G',
     env: {
       NODE_ENV: 'production',
-      PATH: '/home/cinder/Documents/D_Projects/Discord-Github/.venv/bin:' + process.env.PATH
+      PATH: `${BASE}/.venv/bin:` + process.env.PATH
     },
     error_file: './logs/err.log',
     out_file: './logs/out.log',

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,12 +1,14 @@
 [program:discord-github-bot]
-command=/home/cinder/Documents/D_Projects/Discord-Github/.venv/bin/python run.py
-directory=/home/cinder/Documents/D_Projects/Discord-Github
+; Set DISCORD_GITHUB_HOME to the installation directory of the bot.
+; Edit the value below when deploying.
+environment=DISCORD_GITHUB_HOME=/opt/discord-github,PATH="%(ENV_DISCORD_GITHUB_HOME)s/.venv/bin"
+command=%(ENV_DISCORD_GITHUB_HOME)s/.venv/bin/python run.py
+directory=%(ENV_DISCORD_GITHUB_HOME)s
 user=cinder
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/supervisor/discord-github-bot.err.log
 stdout_logfile=/var/log/supervisor/discord-github-bot.out.log
-environment=PATH="/home/cinder/Documents/D_Projects/Discord-Github/.venv/bin"
 redirect_stderr=true
 stdout_logfile_maxbytes=50MB
 stdout_logfile_backups=10


### PR DESCRIPTION
## Summary
- use `DISCORD_GITHUB_HOME` placeholder in systemd service
- allow configuring the project path in `supervisor.conf`
- use env var in `ecosystem.config.js`

## Testing
- `./setup.sh`
- `pytest -q` *(fails: CommandRegistrationError)*

------
https://chatgpt.com/codex/tasks/task_e_68702d4b329c8332af4d9430d5d8a616