### PR TITLE
Fix merge artifacts in tests

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,15 +2,10 @@ import asyncio
 import os
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch, call
-import unittest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import unittest
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
 
@@ -82,8 +77,7 @@ class TestBotCommands(unittest.TestCase):
         mock_load.assert_called_once()
         mock_save.assert_called_once()
         self.ctx.send.assert_awaited()
-=======
-class TestUpdateCommand(unittest.TestCase):
+
     def test_update_sends_embeds_for_prs(self):
         prs = {
             "user/repo1": [

--- a/tests/test_pr_cleanup.py
+++ b/tests/test_pr_cleanup.py
@@ -40,13 +40,17 @@ class TestPRMessageCleanup(unittest.TestCase):
             "repository": {"full_name": "test/repo"},
         }
 
-        with patch("pull_request_handler.send_to_discord", new_callable=AsyncMock, return_value=message):
-
         with patch(
-            "main.send_to_discord", new_callable=AsyncMock, return_value=message
+            "pull_request_handler.send_to_discord",
+            new_callable=AsyncMock,
+            return_value=message,
+        ), patch(
+            "main.send_to_discord",
+            new_callable=AsyncMock,
+            return_value=message,
         ):
-
             asyncio.run(main.route_github_event("pull_request", payload))
+
         data = pr_map.load_pr_map()
         self.assertEqual(data.get("test/repo#1"), 123)
 
@@ -65,19 +69,19 @@ class TestPRMessageCleanup(unittest.TestCase):
             "repository": {"full_name": "test/repo"},
         }
 
-        with patch("pull_request_handler.send_to_discord", new_callable=AsyncMock) as mock_send, \
-             patch(
-                 "discord_bot.discord_bot_instance.delete_message_from_channel",
-                 new_callable=AsyncMock,
-             ) as mock_delete:
-
-        with patch("main.send_to_discord", new_callable=AsyncMock), patch(
+        with patch(
+            "pull_request_handler.send_to_discord",
+            new_callable=AsyncMock,
+        ) as mock_send, patch(
             "discord_bot.discord_bot_instance.delete_message_from_channel",
             new_callable=AsyncMock,
-        ) as mock_delete:
-
+        ) as mock_delete, patch(
+            "main.send_to_discord",
+            new_callable=AsyncMock,
+        ):
             asyncio.run(main.route_github_event("pull_request", payload))
             mock_delete.assert_awaited_with(settings.channel_pull_requests, 456)
+
         data = pr_map.load_pr_map()
         self.assertEqual(data, {})
 

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -2,31 +2,23 @@ import asyncio
 import os
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock, patch, call
 import unittest
+from unittest.mock import AsyncMock, patch, call
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
-
 os.environ.setdefault("GITHUB_TOKEN", "token")
 
 import main
 from config import settings
 from discord_bot import discord_bot_instance
-
-
-import main
-from discord_bot import discord_bot_instance
-from config import settings
-
 from github_utils import RepoStats
 
 
 class TestUpdateStatistics(unittest.TestCase):
     def test_update_statistics(self):
         repo_stats = [
-
             RepoStats("repo1", 5, 2, 1),
             RepoStats("repo2", 3, 1, 1),
         ]
@@ -53,20 +45,29 @@ class TestUpdateStatistics(unittest.TestCase):
         embed = mock_send.await_args_list[0].kwargs["embed"]
         self.assertEqual(embed.title, "repo1")
 
+    def test_update_statistics_ready(self):
+        repo_stats = [
             RepoStats(name="user/repo1", commit_count=5, pr_count=2, merge_count=1),
             RepoStats(name="user/repo2", commit_count=3, pr_count=4, merge_count=2),
         ]
-        with patch("main.gather_repo_stats", new_callable=AsyncMock, return_value=repo_stats), \
-             patch.object(discord_bot_instance, "update_channel_name", new_callable=AsyncMock) as mock_rename, \
-             patch("main.send_to_discord", new_callable=AsyncMock) as mock_send:
+        with patch(
+            "main.gather_repo_stats", new_callable=AsyncMock, return_value=repo_stats
+        ), patch.object(
+            discord_bot_instance, "update_channel_name", new_callable=AsyncMock
+        ) as mock_rename, patch(
+            "main.send_to_discord", new_callable=AsyncMock
+        ) as mock_send:
             discord_bot_instance.ready = True
             asyncio.run(main.update_statistics())
 
-        mock_rename.assert_has_awaits([
-            call(settings.channel_commits, "8-commits"),
-            call(settings.channel_pull_requests, "6-pull-requests"),
-            call(settings.channel_code_merges, "3-merges"),
-        ], any_order=True)
+        mock_rename.assert_has_awaits(
+            [
+                call(settings.channel_commits, "8-commits"),
+                call(settings.channel_pull_requests, "6-pull-requests"),
+                call(settings.channel_code_merges, "3-merges"),
+            ],
+            any_order=True,
+        )
 
         # Verify embed content
         args, kwargs = mock_send.await_args_list[0]
@@ -76,7 +77,6 @@ class TestUpdateStatistics(unittest.TestCase):
         self.assertEqual(fields["Commits"], "5")
         self.assertEqual(fields["Pull Requests"], "2")
         self.assertEqual(fields["Merges"], "1")
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- clean up merge markers and duplicate imports in `tests/test_commands.py`
- fix indentation in `tests/test_pr_cleanup.py`
- rewrite `tests/test_statistics.py` to remove duplicated imports and malformed blocks

## Testing
- `bash setup.sh`
- `pytest -q` *(fails: CommandRegistrationError)*

------
https://chatgpt.com/codex/tasks/task_e_68702d51af948332a6c1bee6764c6651