### PR TITLE
Fix duplicate PR log

### DIFF
--- a/main.py
+++ b/main.py
@@ -174,8 +174,6 @@ async def route_github_event(event_type: str, payload: dict):
 
             logger.info(f"Successfully processed pull_request event")
 
-            logger.info("Successfully processed pull_request event")
-
             if payload.get("action") in {"opened", "closed", "reopened"}:
                 asyncio.create_task(update_github_stats())
         else:

--- a/tests/test_pr_logging.py
+++ b/tests/test_pr_logging.py
@@ -1,0 +1,31 @@
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, patch, MagicMock
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
+
+class TestPullRequestLogging(unittest.TestCase):
+    def test_success_log_once(self):
+        with patch("discord.ext.commands.Bot.add_command"), patch("discord_bot.send_to_discord", new_callable=AsyncMock), patch("discord_bot.discord_bot_instance"):
+            import importlib
+            import main
+            importlib.reload(main)
+
+        payload = {"action": "opened", "pull_request": {}, "repository": {}}
+        with patch("main.handle_pull_request_event_with_retry", new_callable=AsyncMock, return_value=True), \
+             patch("main.send_to_discord", new_callable=AsyncMock), \
+             patch("main.update_github_stats", new_callable=AsyncMock), \
+             patch("asyncio.create_task", return_value=MagicMock()), \
+             self.assertLogs(main.logger, level="INFO") as cm:
+            asyncio.run(main.route_github_event("pull_request", payload))
+
+        log_lines = [line for line in cm.output if "Successfully processed pull_request event" in line]
+        self.assertEqual(len(log_lines), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove redundant log message in main.py
- ensure successful PR logging occurs exactly once

## Testing
- `pytest tests/test_pr_logging.py -q`
- `pytest -q` *(fails: CommandRegistrationError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68702d549ea88332a7ccd90dad09a1c5