### PR TITLE
Fix duplicate update command and update tests

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -11,11 +11,8 @@ import aiohttp
 from logging_config import setup_logging
 from pr_map import load_pr_map, save_pr_map
 from config import settings
-from github_prs import fetch_open_pull_requests
-from formatters import format_pull_request_event
 
 import formatters
-
 
 # Setup logging
 setup_logging()
@@ -286,77 +283,34 @@ async def send_to_discord(
             return await discord_bot_instance.send_to_channel(
                 channel_id, content, embed
             )
+
     else:
         return await discord_bot_instance.send_to_channel(channel_id, content, embed)
 
 
+@bot.command(name="clear")
+async def clear(ctx: commands.Context) -> None:
+    """Clear development-related channels using message purge."""
+    channels = [
+        settings.channel_commits,
+        settings.channel_pull_requests,
+        settings.channel_releases,
+        settings.channel_ci_builds,
+        settings.channel_code_merges,
+    ]
+    await asyncio.gather(
+        *(discord_bot_instance.purge_old_messages(ch, 0) for ch in channels)
+    )
+    await ctx.send("Development channels cleared.")
 
 
-async def fetch_open_pull_requests() -> List[Dict[str, Any]]:
-    """Return a list of open pull requests across all repositories."""
-    if not settings.github_token:
-        logger.error("GitHub token not configured")
-        return []
-
-    headers = {
-        "Accept": "application/vnd.github.v3+json",
-        "Authorization": f"token {settings.github_token}",
-    }
-
-    repos_url = "https://api.github.com/user/repos"
-    params = {"per_page": 100, "visibility": "all", "affiliation": "owner"}
-
-    async with aiohttp.ClientSession() as session:
-        async with session.get(repos_url, headers=headers, params=params) as resp:
-            if resp.status != 200:
-                logger.error("Failed to fetch repositories: %s", resp.status)
-                return []
-            repos = await resp.json()
-
-        prs: List[Dict[str, Any]] = []
-        for repo in repos:
-            repo_name = repo.get("full_name")
-            if not repo_name:
-                continue
-            url = f"https://api.github.com/repos/{repo_name}/pulls"
-            async with session.get(url, headers=headers, params={"state": "open"}) as pr_resp:
-                if pr_resp.status != 200:
-                    logger.error(
-                        "Failed to fetch PRs for %s: %s", repo_name, pr_resp.status
-                    )
-                    continue
-                data = await pr_resp.json()
-                for pr in data:
-                    pr["repository_full_name"] = repo_name
-                    prs.append(pr)
-
-    return prs
+async def clear_channels(ctx: commands.Context) -> None:
+    """Completely purge all development channels."""
+    for channel_id in DEV_CHANNELS:
+        await discord_bot_instance.purge_channel(channel_id)
+    await ctx.send("✅ Channels cleared.")
 
 
-@bot.command(name="update")
-async def update(ctx: commands.Context) -> None:
-    """Populate the pull requests channel with all open PRs."""
-    prs = await fetch_open_pull_requests()
-
-    if not prs:
-        await ctx.send("No open pull requests found.")
-        return
-
-    for pr in prs:
-        payload = {
-            "action": "opened",
-            "pull_request": pr,
-            "repository": {"full_name": pr.get("repository_full_name", "")},
-        }
-        embed = format_pull_request_event(payload)
-        msg = await send_to_discord(settings.channel_pull_requests, embed=embed)
-        if msg:
-            key = f"{pr['repository_full_name']}#{pr['number']}"
-            data = load_pr_map()
-            data[key] = msg.id
-            save_pr_map(data)
-
-    await ctx.send("Pull request channel updated.")
 
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -43,26 +43,22 @@ class TestBotCommands(unittest.TestCase):
         self.ctx.send.assert_awaited_once()
 
     def test_update_command(self):
-        sample_prs = [
-            {
+        sample_prs = [("repo/test", {
                 "number": 1,
                 "title": "Test PR",
                 "html_url": "https://example.com/pr/1",
-                "user": {"login": "tester"},
-                "base": {"repo": {"full_name": "repo/test"}},
-                "repository_full_name": "repo/test",
-            }
-        ]
+                "user": {"login": "tester"}
+            })]
         embed = MagicMock()
         message = MagicMock()
         message.id = 99
 
         with patch(
-            "discord_bot.fetch_open_pull_requests",
+            "github_api.fetch_open_pull_requests",
             new_callable=AsyncMock,
             return_value=sample_prs,
         ) as mock_fetch, patch(
-            "discord_bot.format_pull_request_event",
+            "formatters.format_pull_request_event",
             return_value=embed,
         ) as mock_format, patch(
             "discord_bot.send_to_discord",
@@ -74,7 +70,7 @@ class TestBotCommands(unittest.TestCase):
         ) as mock_load, patch(
             "discord_bot.save_pr_map"
         ) as mock_save:
-            asyncio.run(discord_bot.update(self.ctx))
+            asyncio.run(discord_bot.update_pull_requests(self.ctx))
 
         mock_fetch.assert_awaited_once()
         mock_format.assert_called_once()
@@ -82,30 +78,25 @@ class TestBotCommands(unittest.TestCase):
         mock_load.assert_called_once()
         mock_save.assert_called_once()
         self.ctx.send.assert_awaited()
-=======
 class TestUpdateCommand(unittest.TestCase):
     def test_update_sends_embeds_for_prs(self):
-        prs = {
-            "user/repo1": [
-                {"number": 1, "title": "PR1", "html_url": "http://x/1", "user": {"login": "a"}}
-            ],
-            "user/repo2": [
-                {"number": 2, "title": "PR2", "html_url": "http://x/2", "user": {"login": "b"}}
-            ],
-        }
+        prs = [
+            ("user/repo1", {"number": 1, "title": "PR1", "html_url": "http://x/1", "user": {"login": "a"}}),
+            ("user/repo2", {"number": 2, "title": "PR2", "html_url": "http://x/2", "user": {"login": "b"}}),
+        ]
 
         embed1 = MagicMock()
         embed2 = MagicMock()
 
         with patch(
-            "discord_bot.fetch_open_pull_requests", new_callable=AsyncMock, return_value=prs
+            "github_api.fetch_open_pull_requests", new_callable=AsyncMock, return_value=prs
         ) as mock_fetch, patch(
-            "discord_bot.format_pull_request_event", side_effect=[embed1, embed2]
+            "formatters.format_pull_request_event", side_effect=[embed1, embed2]
         ) as mock_fmt, patch(
             "discord_bot.send_to_discord", new_callable=AsyncMock
         ) as mock_send:
             ctx = MagicMock()
-            asyncio.run(discord_bot.update.callback(ctx))
+            asyncio.run(discord_bot.update_pull_requests.callback(ctx))
 
         mock_fetch.assert_awaited_once()
         self.assertEqual(mock_fmt.call_count, 2)


### PR DESCRIPTION
## Summary
- remove outdated `update` command and old fetch helper
- keep `update_pull_requests` as the only `!update` command
- add missing `clear` and `clear_channels` helpers used in tests
- update tests to reference the remaining command

## Testing
- `bash setup.sh`
- `pytest -q` *(fails: IndentationError in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68702d566c248332b54c0987e7f51a15