### PR TITLE
Fix dynamic stats and PR commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ dependencies along with `pytest`, and executes the test suite with
 
 The bot provides a few convenience commands when interacting directly in Discord.
 
-- `!update` &ndash; Fetch all open pull requests across your repositories and repost them in the pull-requests channel. This is useful if the bot was offline when events occurred.
-- `!clear` &ndash; Remove **all** messages from the main development channels (commits, pull requests, releases, CI builds and code merges).
+- `!pr` &ndash; Fetch all open pull requests across your repositories and repost them in the pull-requests channel. This is useful if the bot was offline when events occurred.
+- `!clear` &ndash; Remove **all** messages from the pull-requests channel.
 - `!setup` &ndash; Create missing channels automatically so the bot can operate in a new server.
 
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -31,29 +31,18 @@ intents.message_content = True
 bot = commands.Bot(command_prefix="!", intents=intents)
 bot.add_command(setup_channels)
 
-# Channels used during development that can be purged with the `!clear` command
-DEV_CHANNELS: list[int] = [
-    settings.channel_commits,
-    settings.channel_pull_requests,
-    settings.channel_releases,
-    settings.channel_code_merges,
-    settings.channel_commits_overview,
-    settings.channel_pull_requests_overview,
-    settings.channel_merges_overview,
-    settings.channel_issues,
-    settings.channel_deployment_status,
-    settings.channel_ci_builds,
-    settings.channel_gollum,
-    settings.channel_bot_logs,
-]
+# Channel that can be purged with the `!clear` command
+PR_CHANNEL: int = settings.channel_pull_requests
 
 
 @bot.command(name="clear")
 async def clear_channels(ctx: commands.Context) -> None:
-    """Clear all messages from development channels."""
-    for channel_id in DEV_CHANNELS:
-        await discord_bot_instance.purge_old_messages(channel_id, 0)
-    await ctx.send("✅ Channels cleared.")
+    """Remove all messages from the pull requests channel."""
+    await discord_bot_instance.purge_channel(PR_CHANNEL)
+    await ctx.send("✅ Pull requests channel cleared.")
+
+# Backwards compatibility for tests importing ``clear``
+clear = clear_channels
 
 
 class DiscordBot:
@@ -309,9 +298,9 @@ async def send_to_discord(
 
 
 
-@bot.command(name="update")
-async def update_pull_requests(ctx: commands.Context) -> None:
-    """Ensure all active pull requests are listed in the pull requests channel."""
+@bot.command(name="pr", aliases=["update"])
+async def populate_pull_requests(ctx: commands.Context) -> None:
+    """Populate the pull requests channel with all open pull requests."""
     from github_api import fetch_open_pull_requests
 
     pr_map_data = load_pr_map()

--- a/tests/test_clear_command.py
+++ b/tests/test_clear_command.py
@@ -2,14 +2,14 @@ import asyncio
 import os
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock, call, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 import unittest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
 
-from discord_bot import clear_channels, DEV_CHANNELS, discord_bot_instance
+from discord_bot import clear_channels, discord_bot_instance, PR_CHANNEL
 
 
 class TestClearCommand(unittest.TestCase):
@@ -17,12 +17,10 @@ class TestClearCommand(unittest.TestCase):
         ctx = MagicMock()
         ctx.send = AsyncMock()
         with patch.object(
-            discord_bot_instance, "purge_old_messages", new_callable=AsyncMock
+            discord_bot_instance, "purge_channel", new_callable=AsyncMock
         ) as mock_purge:
             asyncio.run(clear_channels(ctx))
-            mock_purge.assert_has_awaits(
-                [call(ch, 0) for ch in DEV_CHANNELS], any_order=True
-            )
+            mock_purge.assert_awaited_once_with(PR_CHANNEL)
         ctx.send.assert_awaited_once()
 
 

--- a/tests/test_github_utils.py
+++ b/tests/test_github_utils.py
@@ -34,7 +34,7 @@ class MockSession:
     def __init__(self, responses):
         self._responses = responses
 
-    def get(self, url, headers=None):
+    def get(self, url, headers=None, params=None):
         return self._responses.pop(0)
 
     async def __aenter__(self):
@@ -53,11 +53,12 @@ class TestFetchRepoStats(unittest.TestCase):
     def test_fetch_repo_stats_success(self):
         responses = [
             MockResp(200, [{"full_name": "alice/repo1"}, {"full_name": "alice/repo2"}]),
-            MockResp(200, [], {"Link": "<x?page=5>; rel=\"last\""}),
-            MockResp(200, [], {"Link": "<x?page=3>; rel=\"last\""}),
+            MockResp(200, []),
+            MockResp(200, {"total_count": 5}),
+            MockResp(200, {"total_count": 3}),
             MockResp(200, {"total_count": 2}),
-            MockResp(200, [], {"Link": "<x?page=10>; rel=\"last\""}),
-            MockResp(200, [], {"Link": "<x?page=7>; rel=\"last\""}),
+            MockResp(200, {"total_count": 10}),
+            MockResp(200, {"total_count": 7}),
             MockResp(200, {"total_count": 4}),
         ]
         mock_session = MockSession(responses)
@@ -74,8 +75,9 @@ class TestFetchRepoStats(unittest.TestCase):
     def test_fetch_repo_stats_missing_data(self):
         responses = [
             MockResp(200, [{"full_name": "alice/repo1"}]),
-            MockResp(404),
             MockResp(200, []),
+            MockResp(404),
+            MockResp(200, {"total_count": 1}),
             MockResp(200, {"total_count": 0}),
         ]
         mock_session = MockSession(responses)

--- a/tests/test_pull_request_handler.py
+++ b/tests/test_pull_request_handler.py
@@ -38,7 +38,7 @@ class TestPullRequestHandler(unittest.TestCase):
             "repository": {"full_name": "test/repo"},
         }
         with patch(
-            "pull_request_handler.send_to_discord",
+            "main.send_to_discord",
             new_callable=AsyncMock,
             return_value=message,
         ):

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -18,7 +18,7 @@ class TestSetupCommand(unittest.TestCase):
         ctx.send = AsyncMock()
         guild = MagicMock()
         ctx.guild = guild
-        with patch("utils.channel_manager.ensure_channels", new_callable=AsyncMock) as mock_ensure:
+        with patch("commands.setup.ensure_channels", new_callable=AsyncMock) as mock_ensure:
             mock_ensure.return_value = {"Bot Operations": {"bot-logs": 1}}
             asyncio.run(setup_channels(ctx))
             mock_ensure.assert_awaited_once_with(guild)

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -29,6 +29,7 @@ class TestUpdateStatistics(unittest.TestCase):
         ]
         with patch("main.gather_repo_stats", new_callable=AsyncMock, return_value=repo_stats), \
              patch.object(discord_bot_instance, "update_channel_name", new_callable=AsyncMock) as mock_rename, \
+             patch("main.discord_bot_instance", discord_bot_instance), \
              patch("main.send_to_discord", new_callable=AsyncMock) as mock_send:
             discord_bot_instance.ready = True
             asyncio.run(main.update_statistics())


### PR DESCRIPTION
## Summary
- fetch repo stats from GitHub API and rename channels properly
- allow `!clear` to only wipe the pull requests channel
- rename `!update` to `!pr` and keep alias
- adjust tests for new behaviour

## Testing
- `./setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710c3592208332b4276355a5ae441e