### PR TITLE
Fix duplicate aiohttp import

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -180,7 +180,6 @@ class DiscordBot:
     ):
 
         """Send a message to a Discord webhook URL."""
-        import aiohttp
 
         headers = {"Content-Type": "application/json"}
         data = {}


### PR DESCRIPTION
## Summary
- remove inner aiohttp import from `DiscordBot.send_to_webhook`
- keep module-level import

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687116adb02c8332a071ea78913f05ff