### PR TITLE
Use python3 for venv creation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 # Create virtual environment if it does not already exist
 if [ ! -d ".venv" ]; then
-    python -m venv .venv
+    python3 -m venv .venv
 fi
 
 # Activate the virtual environment


### PR DESCRIPTION
## Summary
- ensure setup.sh builds a venv using `python3 -m venv`

## Testing
- `shellcheck setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711d3ba8f4833292cca6bec4c0fdda