### PR TITLE
Update tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,17 @@ Traefik configuration is included via `traefik.yml`.
 
 ## Tests
 
-Install the requirements and run:
+The test suite runs inside the Python virtual environment created by
+`setup.sh`. If you haven't run the script yet, execute:
 
 ```bash
+./setup.sh
+```
+
+Then activate the environment and run `pytest`:
+
+```bash
+source .venv/bin/activate
 pytest -q
 ```
 


### PR DESCRIPTION
## Summary
- update the README to explain how to activate the `.venv` before running `pytest`
- note that `setup.sh` creates this virtual environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711d3be6a88332943a160c68757989