### PR TITLE
Remove duplicate imports in test_commands

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,10 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, patch, call
 import unittest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import unittest
-from unittest.mock import AsyncMock, MagicMock, call, patch
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")


### PR DESCRIPTION
## Summary
- clean up imports in `tests/test_commands.py`
- avoid duplicate `sys.path.insert` call

## Testing
- `bash setup.sh`
- `source .venv/bin/activate && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711d436dfc83329e4398cc32ba8d7f