### PR TITLE
Update tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,15 @@ Traefik configuration is included via `traefik.yml`.
 
 ## Tests
 
-Install the requirements and run:
+Before running the tests, execute the setup script so the environment has all
+required packages installed:
+
+```bash
+./setup.sh
+```
+
+This installs everything from `requirements.txt` &ndash; including `discord.py`,
+`aiohttp`, and `httpx` &ndash; inside `.venv`. Once setup is complete, run:
 
 ```bash
 pytest -q


### PR DESCRIPTION
## Summary
- remind developers to run `./setup.sh` before `pytest`
- note that it installs requirements such as discord.py, aiohttp and httpx

## Testing
- `./setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711d32d7c08332a4b4973ebe3de32f