### PR TITLE
Fix duplicate imports in tests

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,11 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, patch, call
 import unittest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import unittest
-from unittest.mock import AsyncMock, MagicMock, call, patch
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 
 os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
 


### PR DESCRIPTION
## Summary
- clean up imports in `tests/test_commands.py`

## Testing
- `bash setup.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68711d337fb08332a41faeeefa79aaee