### PR TITLE
Improve send_to_channel readiness logic

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -206,8 +206,7 @@ class DiscordBot:
     ) -> Optional[discord.Message]:
         """Send a message to a specific Discord channel and return the sent message."""
         if not self.ready:
-            logger.warning("Bot is not ready yet, queuing message...")
-            await asyncio.sleep(2)  # Wait a bit for bot to be ready
+            await self.bot.wait_until_ready()
 
         try:
             channel = self.bot.get_channel(channel_id)


### PR DESCRIPTION
## Summary
- await Discord client's readiness before sending

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711d46acf88332b2bbb190f471b2eb