### PR TITLE
Remove unused webhook_url setting

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -21,10 +21,6 @@ GITHUB_TOKEN=your_github_personal_access_token_here
 # GitHub username associated with the token
 GITHUB_USERNAME=your_github_username_here
 
-# Public URL of this webhook service
-WEBHOOK_URL=http://65.21.253.0:8000/github
-
-
 # Agent directories
 AGENTS_DIR=/path/to/agents
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/...
 GITHUB_WEBHOOK_SECRET=secret
 GITHUB_TOKEN=token
 GITHUB_USERNAME=username
-WEBHOOK_URL=http://your-server/github
 
 # Server settings
 HOST=0.0.0.0
@@ -119,7 +118,6 @@ be customised if your Discord server uses different IDs.
 | `GITHUB_WEBHOOK_SECRET` | Secret used to validate GitHub webhooks |
 | `GITHUB_TOKEN` | Personal access token for GitHub API calls |
 | `GITHUB_USERNAME` | GitHub username used by helper scripts |
-| `WEBHOOK_URL` | Base webhook URL when creating webhooks |
 | `HOST` | Bind address for the FastAPI server |
 | `PORT` | Listening port for the FastAPI server |
 | `CHANNEL_COMMITS` | Channel for push events |

--- a/config.py
+++ b/config.py
@@ -17,7 +17,6 @@ class Settings(BaseSettings):
     github_webhook_secret: Optional[str] = None
     github_token: Optional[str] = None
     github_username: Optional[str] = None
-    webhook_url: Optional[str] = None
 
     # Server Configuration
     host: str = "0.0.0.0"


### PR DESCRIPTION
## Summary
- delete `webhook_url` from `Settings`
- drop related entry from `.env.template`
- remove `WEBHOOK_URL` references from docs

## Testing
- `./setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711d47711c8332ade04614767d6b5b