### PR TITLE
Fix duplicate imports in tests

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,20 +4,12 @@ import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch, call
 import unittest
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import unittest
-from unittest.mock import AsyncMock, MagicMock, call, patch
-
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-
 os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
 
 import discord_bot
 from config import settings
-
-
 
 class TestBotCommands(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- deduplicate `import unittest` and `from unittest.mock` in `tests/test_commands.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711d36301c8332a67e23e5cf43770d