### PR TITLE
Enable periodic stats updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The bot posts messages to multiple Discord channels. Override their IDs in `.env
 - `CHANNEL_BOT_LOGS`
 - `PR_CLEANUP_INTERVAL_MINUTES`
 
-The bot can send high-level summaries to dedicated overview channels. Set these IDs in your `.env` file if you want to use them:
+The bot can send high-level summaries to dedicated overview channels. Set these IDs in your `.env` file if you want to use them. The overview channels are renamed every hour with aggregate commit, pull request, and merge counts. The main pull-requests channel is updated every minute to display the current number of open pull requests:
 
 Copy `.env.template` to `.env` and edit each section. The template groups
 variables for easier configuration. A shortened example is shown below:

--- a/tests/test_github_stats.py
+++ b/tests/test_github_stats.py
@@ -39,9 +39,9 @@ class TestGithubStats(unittest.TestCase):
             asyncio.run(main.update_github_stats())
 
         mock_rename.assert_has_awaits([
-            call(settings.channel_commits, "8-commits"),
-            call(settings.channel_pull_requests, "3-pull-requests"),
-            call(settings.channel_code_merges, "1-merges"),
+            call(settings.channel_commits_overview, "8-commits"),
+            call(settings.channel_pull_requests_overview, "3-pull-requests"),
+            call(settings.channel_merges_overview, "1-merges"),
         ], any_order=True)
         self.assertEqual(mock_send.await_count, 3)
         data = stats_map.load_stats_map()

--- a/tests/test_message_purge.py
+++ b/tests/test_message_purge.py
@@ -42,6 +42,10 @@ class TestMessagePurge(unittest.TestCase):
         ) as mock_purge, patch(
             "main.periodic_pr_cleanup", new_callable=AsyncMock
         ) as mock_cleanup, patch(
+            "main.periodic_update_github_stats", new_callable=AsyncMock
+        ) as mock_stats, patch(
+            "main.periodic_update_pull_request_channel", new_callable=AsyncMock
+        ) as mock_pr_update, patch(
             "asyncio.create_task", side_effect=fake_create_task
         ):
             asyncio.run(main.startup_event())
@@ -58,6 +62,8 @@ class TestMessagePurge(unittest.TestCase):
             [call(channel, 5) for channel in channels], any_order=True
         )
         mock_cleanup.assert_awaited_once()
+        mock_stats.assert_awaited_once()
+        mock_pr_update.assert_awaited_once()
 
     def test_purge_removes_pr_map_entries(self):
         pr_map.save_pr_map({"repo#1": 111})

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -38,9 +38,9 @@ class TestUpdateStatistics(unittest.TestCase):
 
         mock_rename.assert_has_awaits(
             [
-                call(settings.channel_commits, "8-commits"),
-                call(settings.channel_pull_requests, "6-pull-requests"),
-                call(settings.channel_code_merges, "3-merges"),
+                call(settings.channel_commits_overview, "8-commits"),
+                call(settings.channel_pull_requests_overview, "6-pull-requests"),
+                call(settings.channel_merges_overview, "3-merges"),
             ],
             any_order=True,
         )


### PR DESCRIPTION
## Summary
- update README to explain PR count refresh
- update stats utilities to rename overview channels
- refresh pull request channel name every minute
- run GitHub stats updates hourly
- adjust unit tests for new behaviour

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711e8d568c8332ad63e92926a94f42