### PR TITLE
Fix embed field overflow in GitHub stats

### DIFF
--- a/stats_map.py
+++ b/stats_map.py
@@ -1,11 +1,11 @@
 import json
 from logging_config import get_state_file_path
-from typing import Dict
+from typing import Dict, List
 
 STATS_MAP_FILE = get_state_file_path("stats_message_map.json")
 
 
-def load_stats_map() -> Dict[str, int]:
+def load_stats_map() -> Dict[str, List[int]]:
     """Load the stats message map from the state file."""
     try:
         with open(STATS_MAP_FILE, "r") as f:
@@ -16,7 +16,7 @@ def load_stats_map() -> Dict[str, int]:
         return {}
 
 
-def save_stats_map(stats_map: Dict[str, int]) -> None:
+def save_stats_map(stats_map: Dict[str, List[int]]) -> None:
     """Save the stats message map to the state file."""
     with open(STATS_MAP_FILE, "w") as f:
         json.dump(stats_map, f, indent=2)


### PR DESCRIPTION
## Summary
- prevent embeds with more than 25 fields by splitting statistics across multiple embeds
- track multiple message IDs in `stats_map`
- add tests for embed splitting logic

## Testing
- `./setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712a1d83508332b6659aa7f3d26d0b