### PR TITLE
Handle Discord embed field limit

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,16 +112,24 @@ async def update_github_stats() -> None:
         for key in totals:
             totals[key] += counts.get(key, 0)
 
-    embeds = {}
+    embeds: dict[str, list[discord.Embed]] = {}
     for key, title in [
         ("commits", "Commit Counts"),
         ("pull_requests", "Pull Request Counts"),
         ("merges", "Merge Counts"),
     ]:
         embed = discord.Embed(title=title, color=discord.Color.blue())
+        embed_list: list[discord.Embed] = []
         for repo, counts in stats.items():
             embed.add_field(name=repo, value=str(counts.get(key, 0)), inline=False)
-        embeds[key] = embed
+            if len(embed.fields) == 25:
+                embed_list.append(embed)
+                embed = discord.Embed(title=title, color=discord.Color.blue())
+        if embed.fields:
+            embed_list.append(embed)
+        if not embed_list:
+            embed_list.append(embed)
+        embeds[key] = embed_list
 
     channel_map = {
         "commits": settings.channel_commits,
@@ -135,22 +143,39 @@ async def update_github_stats() -> None:
             channel_id, f"{totals[key]}-{key.replace('_', '-')}"
         )
 
-        embed = embeds[key]
-        message_id = message_map.get(key)
+        embed_list = embeds[key]
         channel = discord_bot_instance.bot.get_channel(channel_id)
-        if message_id and channel:
-            try:
-                message = await channel.fetch_message(message_id)
-                await message.edit(embed=embed)
-                continue
-            except Exception as exc:
-                logger.warning(
-                    f"Failed to edit stats message in {channel_id}: {exc}"
-                )
+        stored_ids = message_map.get(key, [])
+        new_ids: list[int] = []
 
-        msg = await send_to_discord(channel_id, embed=embed)
-        if msg:
-            message_map[key] = msg.id
+        for idx, embed in enumerate(embed_list):
+            msg_id = stored_ids[idx] if idx < len(stored_ids) else None
+            if msg_id and channel:
+                try:
+                    message = await channel.fetch_message(msg_id)
+                    await message.edit(embed=embed)
+                    new_ids.append(msg_id)
+                    continue
+                except Exception as exc:
+                    logger.warning(
+                        f"Failed to edit stats message in {channel_id}: {exc}"
+                    )
+
+            msg = await send_to_discord(channel_id, embed=embed)
+            if msg:
+                new_ids.append(msg.id)
+
+        if channel and len(stored_ids) > len(embed_list):
+            for extra_id in stored_ids[len(embed_list) :]:
+                try:
+                    message = await channel.fetch_message(extra_id)
+                    await message.delete()
+                except Exception as exc:
+                    logger.warning(
+                        f"Failed to delete old stats message in {channel_id}: {exc}"
+                    )
+
+        message_map[key] = new_ids
 
     save_stats_map(message_map)
 

--- a/stats_map.py
+++ b/stats_map.py
@@ -1,22 +1,25 @@
 import json
 from logging_config import get_state_file_path
-from typing import Dict
+from typing import Dict, List
 
 STATS_MAP_FILE = get_state_file_path("stats_message_map.json")
 
 
-def load_stats_map() -> Dict[str, int]:
+def load_stats_map() -> Dict[str, List[int]]:
     """Load the stats message map from the state file."""
     try:
         with open(STATS_MAP_FILE, "r") as f:
-            return json.load(f)
+            data = json.load(f)
+            if isinstance(data, dict):
+                return {k: list(v) if isinstance(v, list) else [] for k, v in data.items()}
+            return {}
     except FileNotFoundError:
         return {}
     except json.JSONDecodeError:
         return {}
 
 
-def save_stats_map(stats_map: Dict[str, int]) -> None:
+def save_stats_map(stats_map: Dict[str, List[int]]) -> None:
     """Save the stats message map to the state file."""
     with open(STATS_MAP_FILE, "w") as f:
         json.dump(stats_map, f, indent=2)

--- a/tests/test_github_stats.py
+++ b/tests/test_github_stats.py
@@ -46,9 +46,30 @@ class TestGithubStats(unittest.TestCase):
         self.assertEqual(mock_send.await_count, 3)
         data = stats_map.load_stats_map()
         self.assertEqual(data, {
-            "commits": 42,
-            "pull_requests": 42,
-            "merges": 42,
+            "commits": [42],
+            "pull_requests": [42],
+            "merges": [42],
+        })
+
+    def test_update_github_stats_split(self):
+        sample_stats = {
+            f"repo{i}": {"commits": i, "pull_requests": i, "merges": i} for i in range(30)
+        }
+
+        message = MagicMock()
+        message.id = 7
+
+        with patch("main.fetch_repo_stats", new_callable=AsyncMock, return_value=sample_stats), \
+             patch("discord_bot.discord_bot_instance.update_channel_name", new_callable=AsyncMock), \
+             patch("main.send_to_discord", new_callable=AsyncMock, return_value=message) as mock_send:
+            asyncio.run(main.update_github_stats())
+
+        self.assertEqual(mock_send.await_count, 6)
+        data = stats_map.load_stats_map()
+        self.assertEqual(data, {
+            "commits": [7, 7],
+            "pull_requests": [7, 7],
+            "merges": [7, 7],
         })
 
 


### PR DESCRIPTION
## Summary
- split repo stats embeds if there are more than 25 fields
- track multiple stats message IDs
- add regression tests for embed splitting

## Testing
- `./setup.sh`
- `source .venv/bin/activate && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712a1d83508332b6659aa7f3d26d0b