### PR TITLE
Fix embed field overflow

### DIFF
--- a/tests/test_embed_utils.py
+++ b/tests/test_embed_utils.py
@@ -1,0 +1,20 @@
+import unittest
+import discord
+
+from utils.embed_utils import split_embed_fields
+
+
+class TestEmbedUtils(unittest.TestCase):
+    def test_split_embed_fields(self):
+        embed = discord.Embed(title="Test")
+        for i in range(30):
+            embed.add_field(name=f"Field{i}", value=str(i), inline=False)
+
+        embeds = split_embed_fields(embed, max_fields=25)
+        self.assertEqual(len(embeds), 2)
+        self.assertEqual(len(embeds[0].fields), 25)
+        self.assertEqual(len(embeds[1].fields), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -1,0 +1,23 @@
+import discord
+from typing import List
+
+
+def split_embed_fields(embed: discord.Embed, max_fields: int = 25) -> List[discord.Embed]:
+    """Split an embed into multiple embeds if it has more than ``max_fields``."""
+    if len(embed.fields) <= max_fields:
+        return [embed]
+
+    chunks: List[discord.Embed] = []
+    fields = list(embed.fields)
+    for i in range(0, len(fields), max_fields):
+        new_embed = discord.Embed(
+            title=embed.title,
+            description=embed.description,
+            color=embed.color,
+            url=embed.url,
+        )
+        for field in fields[i:i + max_fields]:
+            new_embed.add_field(name=field.name, value=field.value, inline=field.inline)
+        chunks.append(new_embed)
+
+    return chunks


### PR DESCRIPTION
## Summary
- avoid Discord API errors when embed exceeds 25 fields
- split large embeds into smaller ones
- test helper for splitting embeds

## Testing
- `./setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712a1d83508332b6659aa7f3d26d0b