### PR TITLE
Fix embed field limit

### DIFF
--- a/tests/test_send_to_discord.py
+++ b/tests/test_send_to_discord.py
@@ -1,0 +1,32 @@
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
+
+import discord
+import discord_bot
+
+
+class TestSendToDiscord(unittest.TestCase):
+    def test_large_embed_is_split(self):
+        embed = discord.Embed(title="Test")
+        for i in range(30):
+            embed.add_field(name=f"F{i}", value=str(i), inline=False)
+        discord_bot.discord_bot_instance.ready = True
+        with patch.object(
+            discord_bot.discord_bot_instance,
+            "send_to_channel",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            asyncio.run(discord_bot.send_to_discord(123, embed=embed))
+            self.assertEqual(mock_send.await_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- split embeds with more than 25 fields when sending
- test that send_to_discord splits oversized embeds

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_687130b217108332aeee41473a553017