### PR TITLE
Handle oversized embeds splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ For a quicker start you can run the helper script:
 It installs all dependencies inside `.venv` and copies `.env.template` to `.env`
 if needed. See **AGENTS.md** for guidelines on keeping this script current.
 
+Embeds with more than 25 fields are automatically split into multiple messages
+when sent. In this case `send_to_discord()` returns a list of
+`discord.Message` objects representing each embed chunk.
+
 ### Environment Variables
 
 

--- a/tests/test_send_to_discord.py
+++ b/tests/test_send_to_discord.py
@@ -33,6 +33,24 @@ class TestSendToDiscord(unittest.TestCase):
         self.assertEqual(len(first_embed.fields), 25)
         self.assertEqual(len(second_embed.fields), 5)
 
+    def test_large_embed_returns_message_list(self):
+        embed = discord.Embed(title="Test")
+        for i in range(30):
+            embed.add_field(name=f"Field{i}", value=str(i), inline=False)
+
+        messages = [MagicMock(), MagicMock()]
+        with patch.object(
+            discord_bot.discord_bot_instance,
+            "send_to_channel",
+            new_callable=AsyncMock,
+            side_effect=messages,
+        ) as mock_send:
+            result = asyncio.run(discord_bot.send_to_discord(123, embed=embed))
+
+        self.assertEqual(mock_send.await_count, 2)
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, messages)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- split oversized embeds automatically in `DiscordBot.send_to_channel`
- return a list of messages when `send_to_discord` sends multiple embeds
- test returning list of messages for large embeds
- document automatic embed splitting in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871331de1dc83329fc852f99e070b48