### PR TITLE
Remove duplicate test for send_to_discord

### DIFF
--- a/tests/test_send_to_discord.py
+++ b/tests/test_send_to_discord.py
@@ -50,23 +50,22 @@ class TestSendToDiscord(unittest.TestCase):
         self.assertIsInstance(result, list)
         self.assertEqual(result, messages)
 
-    def test_large_embed_returns_message_list(self):
+    def test_small_embed_returns_single_message(self):
         embed = discord.Embed(title="Test")
-        for i in range(30):
+        for i in range(5):
             embed.add_field(name=f"Field{i}", value=str(i), inline=False)
 
-        messages = [MagicMock(), MagicMock()]
+        message = MagicMock()
         with patch.object(
             discord_bot.discord_bot_instance,
             "send_to_channel",
             new_callable=AsyncMock,
-            side_effect=messages,
+            return_value=message,
         ) as mock_send:
             result = asyncio.run(discord_bot.send_to_discord(123, embed=embed))
 
-        self.assertEqual(mock_send.await_count, 2)
-        self.assertIsInstance(result, list)
-        self.assertEqual(result, messages)
+        self.assertEqual(mock_send.await_count, 1)
+        self.assertIs(result, message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove duplicate `test_large_embed_returns_message_list`
- add `test_small_embed_returns_single_message` to verify single embed return value

## Testing
- `./setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713e26fe588332bfdee0ed9411588b