### PR TITLE
Fix duplicate test name

### DIFF
--- a/tests/test_send_to_discord.py
+++ b/tests/test_send_to_discord.py
@@ -50,24 +50,6 @@ class TestSendToDiscord(unittest.TestCase):
         self.assertIsInstance(result, list)
         self.assertEqual(result, messages)
 
-    def test_large_embed_returns_message_list(self):
-        embed = discord.Embed(title="Test")
-        for i in range(30):
-            embed.add_field(name=f"Field{i}", value=str(i), inline=False)
-
-        messages = [MagicMock(), MagicMock()]
-        with patch.object(
-            discord_bot.discord_bot_instance,
-            "send_to_channel",
-            new_callable=AsyncMock,
-            side_effect=messages,
-        ) as mock_send:
-            result = asyncio.run(discord_bot.send_to_discord(123, embed=embed))
-
-        self.assertEqual(mock_send.await_count, 2)
-        self.assertIsInstance(result, list)
-        self.assertEqual(result, messages)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- remove the duplicate `test_large_embed_returns_message_list` definition

## Testing
- `bash -lc './setup.sh'`
- `source .venv/bin/activate && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713e236d388332868e84ca984795d0