### PR TITLE
Fix coroutine warnings in pull request handler tests

### DIFF
--- a/tests/test_pr_logging.py
+++ b/tests/test_pr_logging.py
@@ -16,11 +16,21 @@ class TestPullRequestLogging(unittest.TestCase):
             importlib.reload(main)
 
         payload = {"action": "opened", "pull_request": {}, "repository": {}}
-        with patch("main.handle_pull_request_event_with_retry", new_callable=AsyncMock, return_value=True), \
-             patch("main.send_to_discord", new_callable=AsyncMock), \
-             patch("main.update_github_stats", new_callable=AsyncMock), \
-             patch("asyncio.create_task", return_value=MagicMock()), \
-             self.assertLogs(main.logger, level="INFO") as cm:
+
+        def close_coro(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch(
+            "main.handle_pull_request_event_with_retry",
+            new_callable=AsyncMock,
+            return_value=True,
+        ), patch("main.send_to_discord", new_callable=AsyncMock), patch(
+            "main.update_github_stats",
+            new_callable=AsyncMock,
+        ), patch("asyncio.create_task", side_effect=close_coro), self.assertLogs(
+            main.logger, level="INFO"
+        ) as cm:
             asyncio.run(main.route_github_event("pull_request", payload))
 
         log_lines = [line for line in cm.output if "Successfully processed pull_request event" in line]

--- a/tests/test_pull_request_handler.py
+++ b/tests/test_pull_request_handler.py
@@ -12,7 +12,6 @@ os.environ.setdefault("DISCORD_BOT_TOKEN", "dummy")
 
 import pr_map
 import pull_request_handler
-from config import settings
 
 
 class TestPullRequestHandler(unittest.TestCase):
@@ -58,8 +57,9 @@ class TestPullRequestHandler(unittest.TestCase):
 
         with patch(
             "pull_request_handler.process_pull_request_event",
+            new_callable=AsyncMock,
             side_effect=side_effect,
-        ) as proc, patch("asyncio.sleep", new_callable=AsyncMock) as sleep:
+        ) as proc, patch("asyncio.sleep", new_callable=AsyncMock, return_value=None) as sleep:
             result = asyncio.run(
                 pull_request_handler.handle_pull_request_event_with_retry({}, retries=2, delay=0)
             )
@@ -72,8 +72,10 @@ class TestPullRequestHandler(unittest.TestCase):
             raise RuntimeError("fail")
 
         with patch(
-            "pull_request_handler.process_pull_request_event", side_effect=fail
-        ) as proc, patch("asyncio.sleep", new_callable=AsyncMock) as sleep:
+            "pull_request_handler.process_pull_request_event",
+            new_callable=AsyncMock,
+            side_effect=fail,
+        ) as proc, patch("asyncio.sleep", new_callable=AsyncMock, return_value=None) as sleep:
             result = asyncio.run(
                 pull_request_handler.handle_pull_request_event_with_retry({}, retries=2, delay=0)
             )


### PR DESCRIPTION
## Summary
- adjust pull request handler tests to await async mocks
- close mocked coroutines in PR logging test to avoid unawaited warnings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713e1721e48332b37ad5e79892ff70