### PR TITLE
Refactor PR cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Additional setup and troubleshooting details can be found in the [docs directory
 - **`main.py`** – FastAPI application exposing `/github` and `/health` endpoints.
 - **`discord_bot.py`** – Discord client used to send embeds to channels.
 - **`run.py`** – simple launcher that runs the app with Uvicorn.
-- **Utilities** – scripts like `add_all_webhooks.py` and `cleanup_pr_messages.py` help manage webhooks and message history. Closed pull request messages are cleaned up automatically by the `periodic_pr_cleanup` task at the interval set by `PR_CLEANUP_INTERVAL_MINUTES` (see `cleanup.py`).
+- **Utilities** – scripts like `add_all_webhooks.py` and `cleanup_pr_messages.py` help manage webhooks and message history. `cleanup_pr_messages.py` simply invokes `cleanup.cleanup_pr_messages` to remove stale pull request messages. Closed PR messages are also cleaned up automatically by the `periodic_pr_cleanup` task controlled by `PR_CLEANUP_INTERVAL_MINUTES` (see `cleanup.py`).
 - **`send_to_discord` helper** – automatically splits embeds over 25 fields using `split_embed_fields`.
 
 See the [Channel mapping](docs/ChannelMapping.md) document for routing details.

--- a/cleanup.py
+++ b/cleanup.py
@@ -8,6 +8,8 @@ from config import settings
 from discord_bot import discord_bot_instance
 from pr_map import load_pr_map, save_pr_map
 
+__all__ = ["cleanup_pr_messages", "periodic_pr_cleanup"]
+
 logger = logging.getLogger(__name__)
 GITHUB_API_BASE = "https://api.github.com"
 


### PR DESCRIPTION
## Summary
- expose `cleanup_pr_messages` via `__all__`
- call the cleanup routine from `cleanup_pr_messages.py` instead of duplicating it
- document how the script now works

## Testing
- `source .venv/bin/activate && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713e28880c83329d929ab81bef47d0