### PR TITLE
Fix flake8 unused imports

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -2,9 +2,8 @@
 
 import discord
 from discord.ext import commands
-import asyncio
 import logging
-from typing import Optional, Any, Dict, List
+from typing import Optional, List
 from datetime import datetime, timedelta
 import aiohttp
 
@@ -15,7 +14,6 @@ from config import settings
 from utils.embed_utils import split_embed_fields
 
 from github_api import fetch_open_pull_requests
-from formatters import format_pull_request_event
 from commands.setup import setup_channels
 
 

--- a/main.py
+++ b/main.py
@@ -12,15 +12,13 @@ from config import settings
 from discord_bot import send_to_discord, discord_bot_instance
 from pull_request_handler import handle_pull_request_event_with_retry
 
-from cleanup import cleanup_pr_messages, periodic_pr_cleanup
+from cleanup import periodic_pr_cleanup
 
 
-from pr_map import load_pr_map, save_pr_map
 from github_utils import (
     verify_github_signature,
     is_github_event_relevant,
     gather_repo_stats,
-    RepoStats,
 )
 from github_stats import fetch_repo_stats
 from stats_map import load_stats_map, save_stats_map


### PR DESCRIPTION
## Summary
- clean up unused imports in `discord_bot.py`
- drop unused imports from `main.py`
- verify there are no F401 warnings in project code

## Testing
- `flake8 --exclude .venv | grep F401`


------
https://chatgpt.com/codex/tasks/task_e_68713e1fe97c8332a89e40125f6eb715